### PR TITLE
Proposal: `recompose_base` working with schemas without default values 

### DIFF
--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -289,7 +289,8 @@ class BaseObjectSerializer:
                 ref_obj_str = self.read_transport.get_object(id=ref_hash)
                 if not ref_obj_str:
                     raise SpeckleException(
-                        f"Could not find the referenced child object of id `{ref_hash}` in the given read transport: {self.read_transport.name}"
+                        f"Could not find the referenced child object of id `{ref_hash}`"
+                        f" in the given read transport: {self.read_transport.name}"
                     )
                 ref_obj = json.loads(ref_obj_str)
                 base_object_dict[prop] = self.recompose_base(obj=ref_obj)
@@ -298,7 +299,11 @@ class BaseObjectSerializer:
             else:
                 base_object_dict[prop] = self.handle_value(value)
 
-        base = object_type(**base_object_dict) if object_type else Base(speckle_type=speckle_type)
+        base = (
+            object_type(**base_object_dict)
+            if object_type
+            else Base(speckle_type=speckle_type)
+        )
         base.totalChildrenCount = totalChildrenCount
 
         return base


### PR DESCRIPTION
In the `using_speckle_base` example, I found this note: 

```
    **Important note:** currently the way how serialization works, requires
    each attribute to have a valid default value, just like `foo` has. This includes
    default values for all primitives and complex datastructures.
    Failing to provide a default, breaks the receiving end of the transport.
```

which I found limiting, since we might want to use schemas that require certain values when communicating between parties. 

The following is a proposal to postpone object initialization until all children are parsed. That way, the limitation is lifted. 
I've tested it locally, but since I don't have the dev-server setup I can't run the tests just yet. Sorry for that. 

