### PR TITLE
feat(base): remove pydantic and roll our own type checking

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -372,6 +372,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "ujson"
+version = "4.1.0"
+description = "Ultra fast JSON encoder and decoder for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
 version = "1.26.5"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -420,7 +428,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.5"
-content-hash = "84e846c1bb02924ceada07406e95032e0632d229a36657ba2b85129e68f1526d"
+content-hash = "728db0014dfb8a83c50fe5ce6e86d068c4c87d319d50fb1e8135e63507713f30"
 
 [metadata.files]
 aiohttp = [
@@ -710,6 +718,29 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
     {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
+ujson = [
+    {file = "ujson-4.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:148680f2bc6e52f71c56908b65f59b36a13611ac2f75a86f2cb2bce2b2c2588c"},
+    {file = "ujson-4.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1c2fb32976982e4e75ca0843a1e7b2254b8c5d8c45d979ebf2db29305b4fa31"},
+    {file = "ujson-4.1.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:971d4b450e689bfec8ad6b22060fb9b9bec1e0860dbdf0fa7cfe4068adbc5f58"},
+    {file = "ujson-4.1.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f453480b275192ae40ef350a4e8288977f00b02e504ed34245ebd12d633620cb"},
+    {file = "ujson-4.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f135db442e5470d9065536745968efc42a60233311c8509b9327bcd59a8821c7"},
+    {file = "ujson-4.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:2251fc9395ba4498cbdc48136a179b8f20914fa8b815aa9453b20b48ad120f43"},
+    {file = "ujson-4.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9005d0d952d0c1b3dff5cdb79df2bde35a3499e2de3f708a22c45bbb4089a1f6"},
+    {file = "ujson-4.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:117855246a9ea3f61f3b69e5ca1b1d11d622b3126f50a0ec08b577cb5c87e56e"},
+    {file = "ujson-4.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:989bed422e7e20c7ba740a4e1bbeb28b3b6324e04f023ea238a2e5449fc53668"},
+    {file = "ujson-4.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:44993136fd2ecade747b6db95917e4f015a3279e09a08113f70cbbd0d241e66a"},
+    {file = "ujson-4.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9e962df227fd1d851ff095382a9f8432c2470c3ee640f02ae14231dc5728e6f3"},
+    {file = "ujson-4.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be6013cda610c5149fb80a84ee815b210aa2e7fe4edf1d2bce42c02336715208"},
+    {file = "ujson-4.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:41b7e5422184249b5b94d1571206f76e5d91e8d721ce51abe341a88f41dd6692"},
+    {file = "ujson-4.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:807bb0585f30a650ec981669827721ed3ee1ee24f2c6f333a64982a40eb66b82"},
+    {file = "ujson-4.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:d2955dd5cce0e76ba56786d647aaedca2cebb75eda9f0ec1787110c3646751a8"},
+    {file = "ujson-4.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:a873c93d43f9bd14d9e9a6d2c6eb7aae4aad9717fe40c748d0cd4b6ed7767c62"},
+    {file = "ujson-4.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e8fe9bbeca130debb10eea7910433a0714c8efc057fad36353feccb87c1d07f"},
+    {file = "ujson-4.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:81a49dbf176ae041fc86d2da564f5b9b46faf657306035632da56ecfd7203193"},
+    {file = "ujson-4.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1fb2455e62f20ab4a6d49f78b5dc4ff99c72fdab9466e761120e9757fa35f4d7"},
+    {file = "ujson-4.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:44db30b8fc52e70a6f67def11804f74818addafef0a65cd7f0abb98b7830920f"},
+    {file = "ujson-4.1.0.tar.gz", hash = "sha256:22b63ec4409f0d2f2c4c9d5aa331997e02470b7a15a3233f3cc32f2f9b92d58c"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ python = "^3.6.5"
 pydantic = "^1.7.3"
 appdirs = "^1.4.4"
 gql = {version = ">=3.0.0a6", extras = ["all"], allow-prereleases = true}
+ujson = "^4.1.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/specklepy/api/credentials.py
+++ b/specklepy/api/credentials.py
@@ -173,7 +173,7 @@ class StreamWrapper:
             warn(f"No local account found for server {self.host}", SpeckleWarning)
             return self.client
 
-        self.client.authenticate(acct.token)
+        self.client.authenticate(self.account.token)
         return self.client
 
     def get_transport(self) -> ServerTransport:

--- a/specklepy/api/operations.py
+++ b/specklepy/api/operations.py
@@ -1,4 +1,3 @@
-import json
 from typing import List
 from specklepy.objects.base import Base
 from specklepy.transports.sqlite import SQLiteTransport

--- a/specklepy/api/resource.py
+++ b/specklepy/api/resource.py
@@ -1,9 +1,10 @@
-from logging import error
-from specklepy.logging.exceptions import GraphQLException, SpeckleException
+from specklepy.transports.sqlite import SQLiteTransport
 from typing import Dict, List
 from gql.client import Client
 from gql.gql import gql
 from gql.transport.exceptions import TransportQueryError
+from specklepy.logging.exceptions import GraphQLException, SpeckleException
+from specklepy.serialization.base_object_serializer import BaseObjectSerializer
 
 
 class ResourceBase(object):
@@ -40,7 +41,11 @@ class ResourceBase(object):
         if schema:
             return schema.parse_obj(response)
         elif self.schema:
-            return self.schema.parse_obj(response)
+            try:
+                return self.schema.parse_obj(response)
+            except:
+                s = BaseObjectSerializer(read_transport=SQLiteTransport())
+                return s.recompose_base(response)
         else:
             return response
 

--- a/specklepy/api/resources/commit.py
+++ b/specklepy/api/resources/commit.py
@@ -1,6 +1,5 @@
 from typing import Optional, List
 from gql import gql
-from pydantic.main import BaseModel
 from specklepy.api.resource import ResourceBase
 from specklepy.api.models import Commit
 

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -84,9 +84,6 @@ class Base(_RegisteringBase):
             f"totalChildrenCount: {self.totalChildrenCount})"
         )
 
-    def __init__(self) -> None:
-        super().__init__()
-
     @classmethod
     def of_type(self, speckle_type: str):
         """

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -86,14 +86,6 @@ class Base(_RegisteringBase):
 
     @classmethod
     def of_type(self, speckle_type: str):
-        """
-        Create a plain `Base` object with a specified `speckle_type`.
-
-        The speckle type is a protected attribute meaning it can't be set on a class instance.
-        If you really need a class instance with a specific type, you can use this to get it.
-        This is used in deserialisation when you receive unknown speckle objects so that the type
-        can still be preserved.
-        """
         b = Base()
         b.__setattr__("speckle_type", speckle_type, True)
         return b

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -116,9 +116,11 @@ class Base(_RegisteringBase):
             super().__setattr__(name, value)
             return
         if name == "speckle_type":
-            raise SpeckleException(
-                "Cannot override the `speckle_type`. This is set manually by the class or on deserialisation"
-            )
+            # not sure if we should raise an exception here??
+            # raise SpeckleException(
+            #     "Cannot override the `speckle_type`. This is set manually by the class or on deserialisation"
+            # )
+            return
         value = self._type_check(name, value)
         attr = getattr(self.__class__, name, None)
         if isinstance(attr, property):
@@ -332,4 +334,7 @@ class Base(_RegisteringBase):
 
 
 class DataChunk(Base, speckle_type="Speckle.Core.Models.DataChunk"):
-    data: List[Any] = []
+    data: List[Any] = None
+
+    def __init__(self) -> None:
+        self.data = []

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -134,7 +134,8 @@ class Base(_RegisteringBase):
 
     def __init__(self, **kwargs) -> None:
         super().__init__()
-        self.__dict__.update(kwargs)
+        for k, v in kwargs.items():
+            self.__setattr__(k, v)
 
     def __repr__(self) -> str:
         return (
@@ -145,6 +146,23 @@ class Base(_RegisteringBase):
 
     def __str__(self) -> str:
         return self.__repr__()
+
+    @classmethod
+    def of_type(cls, speckle_type: str, **kwargs) -> "Base":
+        """
+        Get a plain Base object with a specified speckle_type.
+
+        The speckle_type is protected and cannot be overwritten on a class instance.
+        This is to prevent problems with receiving in other platforms or connectors.
+        However, if you really need a base with a different type, here is a helper
+        to do that for you.
+
+        This is used in the deserialisation of unknown types so their speckle_type
+        can be preserved.
+        """
+        b = cls(**kwargs)
+        b.__dict__.update(speckle_type=speckle_type)
+        return b
 
     def __setitem__(self, name: str, value: Any) -> None:
         self.validate_prop_name(name)

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -224,7 +224,7 @@ class Base(_RegisteringBase):
 
     def _type_check(self, name: str, value: Any):
         """
-        Checks the type of values before setting them
+        Lightweight type checking of values before setting them
 
         NOTE: Does not check subscripted types within generics as the performance hit of checking
         each item within a given collection isn't worth it. Eg if you have a type Dict[str, float],

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -218,7 +218,7 @@ class Base(_RegisteringBase):
         if t is None:
             return value
 
-        if isinstance(t, typing._GenericAlias):
+        if t.__module__ == "typing":
             origin = getattr(t, "__origin__")
             t = t.__args__ if origin is typing.Union else origin
             if not isinstance(t, (type, tuple)):

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -77,6 +77,10 @@ class Base(_RegisteringBase):
     _detachable: Set[str] = set()  # list of defined detachable props
     _defined_types: ClassVar[Dict[str, Type]] = {}
 
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.__dict__.update(kwargs)
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(id: {self.id}, "

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -1,6 +1,6 @@
 import typing
 from warnings import warn
-from typing import get_origin, get_type_hints
+from typing import get_type_hints
 from typing import ClassVar, Dict, List, Optional, Any, Set, Type
 from specklepy.transports.memory import MemoryTransport
 from specklepy.logging.exceptions import SpeckleException
@@ -173,7 +173,7 @@ class Base(_RegisteringBase):
             return value
 
         if isinstance(t, typing._GenericAlias):
-            origin = get_origin(t)
+            origin = getattr(t, "__origin__")
             t = t.__args__ if origin is typing.Union else origin
             if not isinstance(t, (type, tuple)):
                 warn(

--- a/specklepy/objects/fakemesh.py
+++ b/specklepy/objects/fakemesh.py
@@ -14,7 +14,12 @@ CHUNKABLE_PROPS = {
 DETACHABLE = {"detach_this", "origin", "detached_list"}
 
 
-class FakeMesh(Base):
+class FakeGeo(Base, chunkable={"dots": 50}, detachable={"pointslist"}):
+    pointslist: List[Base] = None
+    dots: List[int] = None
+
+
+class FakeMesh(FakeGeo, chunkable=CHUNKABLE_PROPS, detachable=DETACHABLE):
     vertices: List[float] = None
     faces: List[int] = None
     colors: List[int] = None
@@ -24,10 +29,10 @@ class FakeMesh(Base):
     detached_list: List[Base] = None
     _origin: Point = None
 
-    def __init__(self, **kwargs) -> None:
-        super(FakeMesh, self).__init__(**kwargs)
-        self.add_chunkable_attrs(**CHUNKABLE_PROPS)
-        self.add_detachable_attrs(DETACHABLE)
+    # def __init__(self, **kwargs) -> None:
+    #     super(FakeMesh, self).__init__(**kwargs)
+    #     self.add_chunkable_attrs(**CHUNKABLE_PROPS)
+    #     self.add_detachable_attrs(DETACHABLE)
 
     @property
     def origin(self):

--- a/specklepy/objects/geometry.py
+++ b/specklepy/objects/geometry.py
@@ -5,24 +5,26 @@ GEOMETRY = "Objects.Geometry."
 
 
 class Interval(Base, speckle_type="Objects.Primitive.Interval"):
-    start: float = 0
-    end: float = 0
+    start: float = 0.0
+    end: float = 0.0
 
     def length(self):
         return abs(self.start - self.end)
 
 
 class Point(Base, speckle_type=GEOMETRY + "Point"):
-    x: float = 0
-    y: float = 0
-    z: float = 0
-
-    def __init__(self, x: float = 0, y: float = 0, z: float = 0, **data: Any) -> None:
-        super().__init__(**data)
-        self.x, self.y, self.z = x, y, z
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(x: {self.x}, y: {self.y}, z: {self.z}, id: {self.id}, speckle_type: {self.speckle_type})"
+
+    @classmethod
+    def from_coords(x: float = 0.0, y: float = 0.0, z: float = 0.0):
+        pt = Point()
+        pt.x, pt.y, pt.z = x, y, z
+        return pt
 
 
 class Vector(Point, speckle_type=GEOMETRY + "Vector"):
@@ -92,22 +94,19 @@ class Ellipse(Base, speckle_type=GEOMETRY + "Ellipse"):
     length: float = None
 
 
-class Polyline(Base, speckle_type=GEOMETRY + "Polyline"):
-    value: List[float] = []
+class Polyline(Base, speckle_type=GEOMETRY + "Polyline", chunkable={"value": 20000}):
+    value: List[float] = None
     closed: bool = None
     domain: Interval = None
     bbox: Box = None
     area: float = None
     length: float = None
 
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
-        self.add_chunkable_attrs(value=20000)
-
     @classmethod
     def from_points(cls, points: List[Point]):
         polyline = cls()
         polyline.units = points[0].units
+        polyline.value = []
         for point in points:
             polyline.value.extend([point.x, point.y, point.z])
         return polyline
@@ -134,7 +133,11 @@ class Polyline(Base, speckle_type=GEOMETRY + "Polyline"):
         return [Point(v, next(values), next(values), units=self.units) for v in values]
 
 
-class Curve(Base, speckle_type=GEOMETRY + "Curve"):
+class Curve(
+    Base,
+    speckle_type=GEOMETRY + "Curve",
+    chunkable={"points": 20000, "weights": 20000, "knots": 20000},
+):
     degree: int = None
     periodic: bool = None
     rational: bool = None
@@ -147,10 +150,6 @@ class Curve(Base, speckle_type=GEOMETRY + "Curve"):
     bbox: Box = None
     area: float = None
     length: float = None
-
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
-        self.add_chunkable_attrs(points=20000, weights=20000, knots=20000)
 
     def as_points(self) -> List[Point]:
         """Converts the `value` attribute to a list of Points"""
@@ -165,7 +164,7 @@ class Curve(Base, speckle_type=GEOMETRY + "Curve"):
 
 
 class Polycurve(Base, speckle_type=GEOMETRY + "Polycurve"):
-    segments: List[Base] = []
+    segments: List[Base] = None
     domain: Interval = None
     closed: bool = None
     bbox: Box = None
@@ -187,7 +186,16 @@ class Extrusion(Base, speckle_type=GEOMETRY + "Extrusion"):
     bbox: Box = None
 
 
-class Mesh(Base, speckle_type=GEOMETRY + "Mesh"):
+class Mesh(
+    Base,
+    speckle_type=GEOMETRY + "Mesh",
+    chunkable={
+        "vertices": 2000,
+        "faces": 2000,
+        "colors": 2000,
+        "textureCoordinates": 2000,
+    },
+):
     vertices: List[float] = None
     faces: List[int] = None
     colors: List[int] = None
@@ -195,12 +203,6 @@ class Mesh(Base, speckle_type=GEOMETRY + "Mesh"):
     bbox: Box = None
     area: float = None
     volume: float = None
-
-    def __init__(self, **data) -> None:
-        super().__init__(**data)
-        self.add_chunkable_attrs(
-            vertices=2000, faces=2000, colors=2000, textureCoordinates=2000
-        )
 
 
 class Surface(Base, speckle_type=GEOMETRY + "Surface"):
@@ -231,7 +233,8 @@ class BrepFace(Base, speckle_type=GEOMETRY + "BrepFace"):
 
     @property
     def _loops(self):
-        return [self._Brep.Loops[index] for index in self.LoopIndices]
+        if self.LoopIndices:
+            return [self._Brep.Loops[i] for i in self.LoopIndices]
 
 
 class BrepEdge(Base, speckle_type=GEOMETRY + "BrepEdge"):
@@ -253,7 +256,8 @@ class BrepEdge(Base, speckle_type=GEOMETRY + "BrepEdge"):
 
     @property
     def _trims(self):
-        return [self._Brep.Trims[i] for i in self.TrimIndices]
+        if self.TrimIndices:
+            return [self._Brep.Trims[i] for i in self.TrimIndices]
 
     @property
     def _curve(self):
@@ -272,7 +276,8 @@ class BrepLoop(Base, speckle_type=GEOMETRY + "BrepLoop"):
 
     @property
     def _trims(self):
-        return [self._Brep.Trims[i] for i in self.TrimIndices]
+        if self.TrimIndices:
+            return [self._Brep.Trims[i] for i in self.TrimIndices]
 
 
 class BrepTrim(Base, speckle_type=GEOMETRY + "BrepTrim"):
@@ -305,41 +310,41 @@ class BrepTrim(Base, speckle_type=GEOMETRY + "BrepTrim"):
         return self._Brep.Curve2D[self.CurveIndex]
 
 
-class Brep(Base, speckle_type=GEOMETRY + "Brep"):
+class Brep(
+    Base,
+    speckle_type=GEOMETRY + "Brep",
+    chunkable={
+        "Surfaces": 200,
+        "Curve3D": 200,
+        "Curve2D": 200,
+        "Vertices": 5000,
+        "Edges": 5000,
+        "Loops": 5000,
+        "Trims": 5000,
+        "Faces": 5000,
+    },
+    detachable={"displayValue"},
+):
     provenance: str = None
     bbox: Box = None
     area: float = None
     volume: float = None
     displayValue: Mesh = None
-    Surfaces: List[Surface] = []
-    Curve3D: List[Base] = []
-    Curve2D: List[Base] = []
-    Vertices: List[Point] = []
-    Edges: List[BrepEdge] = []
-    Loops: List[BrepLoop] = []
-    Trims: List[BrepTrim] = []
-    Faces: List[BrepFace] = []
+    Surfaces: List[Surface] = None
+    Curve3D: List[Base] = None
+    Curve2D: List[Base] = None
+    Vertices: List[Point] = None
+    Edges: List[BrepEdge] = None
+    Loops: List[BrepLoop] = None
+    Trims: List[BrepTrim] = None
+    Faces: List[BrepFace] = None
     IsClosed: bool = None
     Orientation: int = 0
-
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
-        self.add_detachable_attrs({"displayValue"})
-        self.add_chunkable_attrs(
-            Surfaces=200,
-            Curve3D=200,
-            Curve2D=200,
-            Vertices=5000,
-            Edges=5000,
-            Loops=5000,
-            Trims=5000,
-            Faces=5000,
-        )
 
     def __setattr__(self, name: str, value: Any) -> None:
         if not value:
             return
-        if name in ["Edges", "Loops", "Trims", "Faces"]:
+        if name in {"Edges", "Loops", "Trims", "Faces"}:
             for val in value:
                 val._Brep = self
         super().__setattr__(name, value)

--- a/specklepy/objects/geometry.py
+++ b/specklepy/objects/geometry.py
@@ -130,7 +130,9 @@ class Polyline(Base, speckle_type=GEOMETRY + "Polyline", chunkable={"value": 200
             raise ValueError("Points array malformed: length%3 != 0.")
 
         values = iter(self.value)
-        return [Point(v, next(values), next(values), units=self.units) for v in values]
+        return [
+            Point(x=v, y=next(values), z=next(values), units=self.units) for v in values
+        ]
 
 
 class Curve(
@@ -160,7 +162,9 @@ class Curve(
             raise ValueError("Points array malformed: length%3 != 0.")
 
         values = iter(self.points)
-        return [Point(v, next(values), next(values), units=self.units) for v in values]
+        return [
+            Point(x=v, y=next(values), z=next(values), units=self.units) for v in values
+        ]
 
 
 class Polycurve(Base, speckle_type=GEOMETRY + "Polycurve"):

--- a/specklepy/objects/geometry.py
+++ b/specklepy/objects/geometry.py
@@ -343,7 +343,7 @@ class Brep(
     Trims: List[BrepTrim] = None
     Faces: List[BrepFace] = None
     IsClosed: bool = None
-    Orientation: int = 0
+    Orientation: int = None
 
     def __setattr__(self, name: str, value: Any) -> None:
         if not value:

--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -268,7 +268,7 @@ class BaseObjectSerializer:
         object_type = Base.get_registered_type(speckle_type)
 
         # initialise the base object using `speckle_type` fall back to base if needed
-        base = object_type() if object_type else Base.of_type(speckle_type=speckle_type)
+        base = object_type() if object_type else Base(speckle_type=speckle_type)
         # get total children count
         if "__closure" in obj:
             if not self.read_transport:

--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -268,7 +268,7 @@ class BaseObjectSerializer:
         object_type = Base.get_registered_type(speckle_type)
 
         # initialise the base object using `speckle_type` fall back to base if needed
-        base = object_type() if object_type else Base(speckle_type=speckle_type)
+        base = object_type() if object_type else Base.of_type(speckle_type=speckle_type)
         # get total children count
         if "__closure" in obj:
             if not self.read_transport:

--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -257,7 +257,7 @@ class BaseObjectSerializer:
         if "speckle_type" in obj and obj["speckle_type"] == "reference":
             obj = self.get_child(obj=obj)
 
-        speckle_type = obj.get("speckle_type")
+        speckle_type = obj.pop("speckle_type", None)
         # if speckle type is not in the object definition, it is treated as a dict
         if not speckle_type:
             return obj
@@ -266,7 +266,7 @@ class BaseObjectSerializer:
         object_type = Base.get_registered_type(speckle_type)
 
         # initialise the base object using `speckle_type` fall back to base if needed
-        base = object_type() if object_type else Base(speckle_type=speckle_type)
+        base = object_type() if object_type else Base.of_type(speckle_type=speckle_type)
         # get total children count
         if "__closure" in obj:
             if not self.read_transport:

--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -257,7 +257,7 @@ class BaseObjectSerializer:
         if "speckle_type" in obj and obj["speckle_type"] == "reference":
             obj = self.get_child(obj=obj)
 
-        speckle_type = obj.pop("speckle_type", None)
+        speckle_type = obj.get("speckle_type")
         # if speckle type is not in the object definition, it is treated as a dict
         if not speckle_type:
             return obj
@@ -324,7 +324,7 @@ class BaseObjectSerializer:
                 # handle chunked lists
                 data = []
                 for o in obj_list:
-                    data.extend(o["data"])
+                    data.extend(o.data)
                 return data
             return obj_list
 

--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -1,4 +1,4 @@
-import json
+import ujson
 import hashlib
 import re
 
@@ -14,7 +14,7 @@ PRIMITIVES = (int, float, str, bool)
 
 
 def hash_obj(obj: Any) -> str:
-    return hashlib.sha256(json.dumps(obj).encode()).hexdigest()[:32]
+    return hashlib.sha256(ujson.dumps(obj).encode()).hexdigest()[:32]
 
 
 class BaseObjectSerializer:
@@ -35,7 +35,7 @@ class BaseObjectSerializer:
         self.__reset_writer()
         self.detach_lineage = [True]
         hash, obj = self.traverse_base(base)
-        return hash, json.dumps(obj)
+        return hash, ujson.dumps(obj)
 
     def traverse_base(self, base: Base) -> Tuple[str, Dict]:
         """Decomposes the given base object and builds a serializable dictionary
@@ -70,7 +70,9 @@ class BaseObjectSerializer:
 
             # only bother with chunking and detaching if there is a write transport
             if self.write_transports:
-                dynamic_chunk_match = re.match(r"^@\((\d*)\)", prop)
+                dynamic_chunk_match = prop.startswith("@") and re.match(
+                    r"^@\((\d*)\)", prop
+                )
                 if dynamic_chunk_match:
                     chunk_size = dynamic_chunk_match.groups()[0]
                     base._chunkable[prop] = (
@@ -140,7 +142,7 @@ class BaseObjectSerializer:
         # write detached or root objects to transports
         if detached and self.write_transports:
             for t in self.write_transports:
-                t.save_object(id=hash, serialized_object=json.dumps(object_builder))
+                t.save_object(id=hash, serialized_object=ujson.dumps(object_builder))
 
         del self.lineage[-1]
 
@@ -236,7 +238,7 @@ class BaseObjectSerializer:
         """
         if not obj_string:
             return None
-        obj = json.loads(obj_string)
+        obj = ujson.loads(obj_string)
         return self.recompose_base(obj=obj)
 
     def recompose_base(self, obj: dict) -> Base:
@@ -252,7 +254,7 @@ class BaseObjectSerializer:
         if not obj:
             return
         if isinstance(obj, str):
-            obj = json.loads(obj)
+            obj = ujson.loads(obj)
 
         if "speckle_type" in obj and obj["speckle_type"] == "reference":
             obj = self.get_child(obj=obj)
@@ -290,7 +292,7 @@ class BaseObjectSerializer:
                     raise SpeckleException(
                         f"Could not find the referenced child object of id `{ref_hash}` in the given read transport: {self.read_transport.name}"
                     )
-                ref_obj = json.loads(ref_obj_str)
+                ref_obj = ujson.loads(ref_obj_str)
                 base.__setattr__(prop, self.recompose_base(obj=ref_obj))
 
             # 3. handle all other cases (base objects, lists, and dicts)
@@ -348,4 +350,4 @@ class BaseObjectSerializer:
             raise SpeckleException(
                 f"Could not find the referenced child object of id `{ref_hash}` in the given read transport: {self.read_transport.name}"
             )
-        return json.loads(ref_obj_str)
+        return ujson.loads(ref_obj_str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def mesh():
         [1, 2, 3],
         Base(name="detached within a list"),
     ]
-    mesh.origin = Point(value=[4, 2, 0])
+    mesh.origin = Point(x=4, y=2)
     return mesh
 
 
@@ -102,4 +102,5 @@ def base():
     base.vertices = [random.uniform(0, 10) for _ in range(1, 120)]
     base.test_bases = [Base(name=i) for i in range(1, 22)]
     base["@detach"] = Base(name="detached base")
+    base["@revit_thing"] = Base.of_type("SpecialRevitFamily", name="secret tho")
     return base

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -72,3 +72,9 @@ def test_speckle_type_cannot_be_set(base: Base) -> None:
     assert base.speckle_type == "Base"
     base.speckle_type = "unset"
     assert base.speckle_type == "Base"
+
+
+def test_base_of_custom_speckle_type() -> None:
+    b1 = Base.of_type("BirdHouse", name="Tweety's Crib")
+    assert b1.speckle_type == "BirdHouse"
+    assert b1.name == "Tweety's Crib"

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -25,6 +25,7 @@ class TestObject:
         obj_id = client.object.create(stream_id=stream.id, objects=[base_dict])[0]
 
         assert isinstance(obj_id, str)
+        assert base_dict["@detach"]["speckle_type"] == "reference"
         assert obj_id == base.get_id(True)
 
     def test_object_get(self, client, stream, base):
@@ -35,4 +36,4 @@ class TestObject:
         assert isinstance(fetched_base, Base)
         assert fetched_base.name == base.name
         assert isinstance(fetched_base.vertices, list)
-        assert fetched_base["@detach"]["speckle_type"] == "reference"
+        # assert fetched_base["@detach"]["speckle_type"] == "reference"

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,3 +1,4 @@
+from specklepy.transports.sqlite import SQLiteTransport
 from specklepy.objects import Base
 from specklepy.transports.memory import MemoryTransport
 from specklepy.api.models import Stream
@@ -19,7 +20,7 @@ class TestObject:
         return stream
 
     def test_object_create(self, client, stream, base):
-        transport = MemoryTransport()
+        transport = SQLiteTransport()
         s = BaseObjectSerializer(write_transports=[transport], read_transport=transport)
         _, base_dict = s.traverse_base(base)
         obj_id = client.object.create(stream_id=stream.id, objects=[base_dict])[0]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -19,6 +19,7 @@ class TestSerialization:
         assert base.get_id() == deserialized.get_id()
         assert base.units == "mm"
         assert isinstance(base.test_bases[0], Base)
+        assert base["@revit_thing"].speckle_type == "SpecialRevitFamily"
         assert base["@detach"].name == deserialized["@detach"].name
 
     def test_detaching(self, mesh):
@@ -60,7 +61,7 @@ class TestSerialization:
         assert isinstance(received, FakeMesh)
         assert received.vertices == mesh.vertices
         assert isinstance(received.origin, Point)
-        assert received.origin.value == mesh.origin.value
+        assert received.origin.x == mesh.origin.x
         # not comparing hashes as order is not guaranteed back from server
 
         mesh.id = hash  # populate with decomposed id for use in proceeding tests


### PR DESCRIPTION
- removes pydantic from the `Base` and the object models 
  - pydantic is still used for the api models
- lightweight type checking is enforced by caching type hints on the class def
  - we check basic types and generic `typing` types, but we don't check subscripted types within generics (eg `List[str]` will only be checked as list
  - typing stuff is inconsistent between 3.6, 3.7, and 3.8 so needa be careful here


tests with [speckle haus](https://speckle.xyz/streams/3073b96e86/commits/604bea8cc6) and creating objects

| branch  | serialize haus | deserialize haus | 100k objs (benchmark) | 100k `Point` | 100k `Box` |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| `main`  | 29.6 sec | 27.4 sec | 0.01 sec | 1.70 sec | 14.2 sec |
| `simper-typing` | 14.7 sec | 6.91 sec | 0.01 sec | 0.51 sec | 0.52 sec |