### PR TITLE
chore(dev): add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT="3.9"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+USER vscode
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+
+ENV PATH=$PATH:$HOME/.poetry/env

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/python-3
+{
+	"name": "Python 3",
+	// "build": {
+	// 	"dockerfile": "Dockerfile",
+	// 	"context": "..",
+	// 	"args": {
+	// 		// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+	// 		"VARIANT": "3.6",
+	// 		// Options
+	// 		"NODE_VERSION": "lts/*"
+	// 	}
+	// },
+	"dockerComposeFile": "./docker-compose.yaml",
+	"service": "specklepy",
+	"workspaceFolder": "/workspaces/specklepy",
+	"shutdownAction": "stopCompose",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"python.testing.pytestArgs": [
+			"tests/",
+			"-s"
+		],
+		"python.testing.pytestEnabled": true,
+		"editor.formatOnSave": true,
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "poetry config virtualenvs.create false && poetry install",
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,49 @@
+version: "3.3"  # optional since v1.27.0
+services:
+  postgres:
+    image: circleci/postgres:12
+    environment:
+      POSTGRES_DB: speckle2_test
+      POSTGRES_PASSWORD: speckle
+      POSTGRES_USER: speckle
+      # ports:
+      #   - "5432:5432"
+    network_mode: host
+  redis:
+    image: circleci/redis:6
+    # ports:
+    #   - "6379:6379"
+    network_mode: host
+  speckle-server:
+    image: speckle/speckle-server
+    command: ["bash", "-c", "/wait && node bin/www"]
+    environment:
+      POSTGRES_URL: "localhost"
+      POSTGRES_USER: "speckle"
+      POSTGRES_PASSWORD: "speckle"
+      POSTGRES_DB: "speckle2_test"
+      REDIS_URL: "redis://localhost"
+      SESSION_SECRET: "keyboard cat"
+      STRATEGY_LOCAL: "true"
+      CANONICAL_URL: "http://localhost:3000"
+      WAIT_HOSTS: localhost:5432, localhost:6379
+    # ports:
+    #   - "3000:3000"
+    network_mode: host
+
+  specklepy:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      args:
+        VARIANT: 3.6
+        NODE_VERSION: lts/*
+    volumes:
+      # Mounts the project folder to '/workspace'. While this file is in .devcontainer,
+      # mounts are relative to the first file in the list, which is a level up.
+      - ..:/workspaces/specklepy:cached
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    network_mode: host
+# networks:
+#     default:


### PR DESCRIPTION
This makes it easier to develop and run tests against an environment that has the right python virtualenv + a local speckle server + postgres + redis instance/

You can get started in VSCode by using `CTRL + SHIFT + P` (or something else on Max I guess :upside_down_face: ). You can find more info about VSCode devcontainers and how to use them [here](https://code.visualstudio.com/docs/remote/create-dev-container).