### PR TITLE
fix(client): add `branchName` to commits query

### DIFF
--- a/specklepy/api/models.py
+++ b/specklepy/api/models.py
@@ -30,7 +30,7 @@ class Commit(BaseModel):
     parents: Optional[List[str]]
 
     def __repr__(self) -> str:
-        return f"Commit( id: {self.id}, message: {self.message}, referencedObject: {self.referencedObject}, authorName: {self.authorName}, createdAt: {self.createdAt} )"
+        return f"Commit( id: {self.id}, message: {self.message}, referencedObject: {self.referencedObject}, authorName: {self.authorName}, branchName: {self.branchName}, createdAt: {self.createdAt} )"
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/specklepy/api/resources/commit.py
+++ b/specklepy/api/resources/commit.py
@@ -34,8 +34,8 @@ class Resource(ResourceBase):
                 stream(id: $stream_id) {
                     commit(id: $commit_id) {
                         id
-                        referencedObject
                         message
+                        referencedObject
                         authorId
                         authorName
                         authorAvatar
@@ -79,6 +79,7 @@ class Resource(ResourceBase):
                             authorId
                             authorName
                             authorAvatar
+                            branchName
                             createdAt
                             sourceApplication
                             totalChildrenCount


### PR DESCRIPTION
thanks morten for spotting this!

- adds the `branchName` to `commits.list` query
- adds `branchName` to the commit model `repr` for funsies - it's prob nice to see there 

closes #142 