### PR TITLE
fix(units): warn and don't set for invalid args

### DIFF
--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -313,7 +313,9 @@ class Base(_RegisteringBase):
 
     @units.setter
     def units(self, value: str):
-        self._units = get_units_from_string(value)
+        units = get_units_from_string(value)
+        if units:
+            self._units = units
 
     def get_member_names(self) -> List[str]:
         """Get all of the property names on this object, dynamic or not"""

--- a/specklepy/objects/units.py
+++ b/specklepy/objects/units.py
@@ -1,4 +1,5 @@
-from specklepy.logging.exceptions import SpeckleException
+from warnings import warn
+from specklepy.logging.exceptions import SpeckleException, SpeckleWarning
 
 UNITS = ["mm", "cm", "m", "in", "ft", "yd", "mi"]
 
@@ -28,6 +29,12 @@ UNITS_ENCODINGS = {
 
 
 def get_units_from_string(unit: str):
+    if not isinstance(unit, str):
+        warn(
+            f"Invalid units: expected type str but received {type(unit)} ({unit}). Skipping - no units will be set.",
+            SpeckleWarning,
+        )
+        return
     unit = str.lower(unit)
     for name, alternates in UNITS_STRINGS.items():
         if unit in alternates:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -77,6 +77,18 @@ def test_speckle_type_cannot_be_set(base: Base) -> None:
     assert base.speckle_type == "Base"
 
 
+def test_setting_units():
+    b = Base(units="foot")
+    assert b.units == "ft"
+
+    with pytest.raises(SpeckleException):
+        b.units = "big"
+
+    b.units = None  # invalid args are skipped
+    b.units = 7
+    assert b.units == "ft"
+
+
 def test_base_of_custom_speckle_type() -> None:
     b1 = Base.of_type("BirdHouse", name="Tweety's Crib")
     assert b1.speckle_type == "BirdHouse"


### PR DESCRIPTION
https://speckle.community/t/bug-when-receiving-revit-data-in-python-speckle-client/2168