### PR TITLE
chore(dev): update py and fix EOL errors

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       dockerfile: Dockerfile
       context: .
       args:
-        VARIANT: 3.6
+        VARIANT: 3.9
         NODE_VERSION: lts/*
     volumes:
       # Mounts the project folder to '/workspace'. While this file is in .devcontainer,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
updates python version in dev container to 3.9 and adds a `.gitattributes` file to fix EOL prob on windows within the container

will wait a bit to merge in case antoine has a specific reason for using py 3.6