### PR TITLE
feat(metrics): some cleanup and updates

### DIFF
--- a/specklepy/api/resources/server.py
+++ b/specklepy/api/resources/server.py
@@ -2,6 +2,7 @@ from typing import Dict, List
 from gql import gql
 from specklepy.api.models import ServerInfo
 from specklepy.api.resource import ResourceBase
+from specklepy.logging import metrics
 
 
 NAME = "server"
@@ -26,6 +27,7 @@ class Resource(ResourceBase):
         Returns:
             dict -- the server info in dictionary form
         """
+        metrics.track(metrics.SERVER, self.account, {"name": "get"})
         query = gql(
             """
             query Server {
@@ -65,6 +67,7 @@ class Resource(ResourceBase):
         Returns:
             dict -- a dictionary of apps registered on the server
         """
+        metrics.track(metrics.SERVER, self.account, {"name": "apps"})
         query = gql(
             """
             query Apps {
@@ -98,6 +101,7 @@ class Resource(ResourceBase):
         Returns:
             str -- the new API token. note: this is the only time you'll see the token!
         """
+        metrics.track(metrics.SERVER, self.account, {"name": "create_token"})
         query = gql(
             """
             mutation TokenCreate($token: ApiTokenCreateInput!) {
@@ -123,6 +127,7 @@ class Resource(ResourceBase):
         Returns:
             bool -- True if the token was successfully deleted
         """
+        metrics.track(metrics.SERVER, self.account, {"name": "revoke_token"})
         query = gql(
             """
             mutation TokenRevoke($token: String!) {

--- a/specklepy/logging/metrics.py
+++ b/specklepy/logging/metrics.py
@@ -1,5 +1,3 @@
-import json
-import os
 import socket
 import sys
 import queue
@@ -14,6 +12,7 @@ This really helps us to deliver a better open source project and product!
 """
 TRACK = True
 HOST_APP = "python"
+HOST_APP_VERSION = f"python {'.'.join(map(str, sys.version_info[:3]))}"
 PLATFORMS = {"win32": "Windows", "cygwin": "Windows", "darwin": "Mac OS X"}
 
 LOG = logging.getLogger(__name__)
@@ -27,6 +26,8 @@ PERMISSION = "Permission Action"
 COMMIT = "Commit Action"
 BRANCH = "Branch Action"
 USER = "User Action"
+SERVER = "Server Action"
+CLIENT = "Speckle Client"
 STREAM_WRAPPER = "Stream Wrapper"
 
 ACCOUNTS = "Get Local Accounts"
@@ -45,9 +46,10 @@ def enable():
     TRACK = True
 
 
-def set_host_app(host_app: str):
+def set_host_app(host_app: str, host_app_version: str = None):
     global HOST_APP
     HOST_APP = host_app
+    HOST_APP_VERSION = host_app_version or HOST_APP_VERSION
 
 
 def track(action: str, account: "Account" = None, custom_props: dict = None):
@@ -62,6 +64,7 @@ def track(action: str, account: "Account" = None, custom_props: dict = None):
                 "server_id": METRICS_TRACKER.last_server,
                 "token": METRICS_TRACKER.analytics_token,
                 "hostApp": HOST_APP,
+                "hostAppVersion": HOST_APP_VERSION,
                 "$os": METRICS_TRACKER.platform,
                 "type": "action",
             },


### PR DESCRIPTION
- add py version to metrics to ensure it's safe to drop 3.6 support
- add metrics for client init / auth
- add server metrics
- remove incompatible server check in client
(at this point, it's been long enough that I think it's fine and will
save time on request / esp in places like blender)