### PR TITLE
fix(metrics): remove unused prop

### DIFF
--- a/specklepy/logging/metrics.py
+++ b/specklepy/logging/metrics.py
@@ -101,7 +101,6 @@ class Singleton(type):
 class MetricsTracker(metaclass=Singleton):
     analytics_url = "https://analytics.speckle.systems/track?ip=1"
     analytics_token = "acd87c5a50b56df91a795e999812a3a4"
-    user_ip = None
     last_user = None
     last_server = None
     platform = None
@@ -114,7 +113,6 @@ class MetricsTracker(metaclass=Singleton):
         )
         self.platform = PLATFORMS.get(sys.platform, "linux")
         self.sending_thread.start()
-        self.user_ip = socket.gethostbyname(socket.gethostname())
 
     def set_last_user(self, email: str):
         if not email:


### PR DESCRIPTION
some environments may throw an error when trying to `socket.gethostbyname`. not sure exactly what kind of env this would be, but it was reported here

https://speckle.community/t/specklepy-get-default-account-error/3085

however, the prop this is used for `user_ip` is no longer needed in the metrics request so i think it's easier and cleaner to just remove it