### PR TITLE
fix(base): remove default units to `Base`

### DIFF
--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -142,7 +142,7 @@ class Base(_RegisteringBase):
     id: Optional[str] = None
     totalChildrenCount: Optional[int] = None
     applicationId: Optional[str] = None
-    _units: str = "m"
+    _units: str = None
     # dict of chunkable props and their max chunk size
     _chunkable: Dict[str, int] = {}
     _chunk_size_default: int = 1000

--- a/specklepy/objects/units.py
+++ b/specklepy/objects/units.py
@@ -16,6 +16,7 @@ UNITS_STRINGS = {
 }
 
 UNITS_ENCODINGS = {
+    None: 0,
     "none": 0,
     "mm": 1,
     "cm": 2,
@@ -58,7 +59,5 @@ def get_units_from_encoding(unit: int):
 def get_encoding_from_units(unit: str):
     try:
         return UNITS_ENCODINGS[unit]
-    except KeyError:
-        raise SpeckleException(
-            message=f"No encoding exists for unit {unit}. Please enter a valid unit to encode (eg {UNITS_ENCODINGS})."
-        )
+    except KeyError as e:
+        raise SpeckleException(message=f"No encoding exists for unit {unit}. Please enter a valid unit to encode (eg {UNITS_ENCODINGS}).") from e


### PR DESCRIPTION
change in sharp that wasn't propagated to py!

also fix resulting encoding issue without a default unit