### PR TITLE
fix(transport): call begin/end write in server

### DIFF
--- a/specklepy/transports/server/server.py
+++ b/specklepy/transports/server/server.py
@@ -157,32 +157,12 @@ class ServerTransport(AbstractTransport):
 
         # iter through returned objects saving them as we go
         target_transport.begin_write()
-        
         for line in lines:
             if line:
                 hash, obj = line.split("\t")
                 target_transport.save_object(hash, obj)
 
         target_transport.save_object(id, root_obj_serialized)
-
         target_transport.end_write()
 
         return root_obj_serialized
-
-    # async def stream_res(self, endpoint: str) -> str:
-    #     data = b""
-    #     async with aiohttp.ClientSession() as session:
-    #         session.headers.update(
-    #             {
-    #                 "Authorization": f"{self.session.headers['Authorization']}",
-    #                 "Accept": "text/plain",
-    #             }
-    #         )
-    #         async with session.get(endpoint) as res:
-    #             while True:
-    #                 chunk = await res.content.read(self.chunk_size)
-    #                 if not chunk:
-    #                     break
-    #                 data += chunk
-
-    #     return data.decode("utf-8")

--- a/specklepy/transports/server/server.py
+++ b/specklepy/transports/server/server.py
@@ -156,12 +156,16 @@ class ServerTransport(AbstractTransport):
         lines = r.iter_lines(decode_unicode=True)
 
         # iter through returned objects saving them as we go
+        target_transport.begin_write()
+        
         for line in lines:
             if line:
                 hash, obj = line.split("\t")
                 target_transport.save_object(hash, obj)
 
         target_transport.save_object(id, root_obj_serialized)
+
+        target_transport.end_write()
 
         return root_obj_serialized
 


### PR DESCRIPTION
when calling `copy_objects_and_children`, target transport needs to be notified of begin and end write