### PR TITLE
fix(credentials): clean up sqlite transport directly after getting accts

### DIFF
--- a/specklepy/api/credentials.py
+++ b/specklepy/api/credentials.py
@@ -51,6 +51,8 @@ def get_local_accounts(base_path: str = None) -> List[Account]:
 
     accounts = []
     res = account_storage.get_all_objects()
+    account_storage.close()
+
     if res:
         accounts.extend(Account.parse_raw(r[1]) for r in res)
     if json_acct_files:
@@ -60,10 +62,8 @@ def get_local_accounts(base_path: str = None) -> List[Account]:
                 for json_file in json_acct_files
             )
         except Exception as ex:
-            raise SpeckleException(
-                "Invalid json accounts could not be read. Please fix or remove them.",
-                ex,
-            )
+            raise SpeckleException("Invalid json accounts could not be read. Please fix or remove them.", ex) from ex
+
     metrics.track(
         metrics.ACCOUNTS,
         next(

--- a/specklepy/transports/sqlite.py
+++ b/specklepy/transports/sqlite.py
@@ -188,4 +188,4 @@ class SQLiteTransport(AbstractTransport):
             self.__connection = sqlite3.connect(self._root_path)
 
     def __del__(self):
-        self.__connection.close()
+        self.close()


### PR DESCRIPTION
due to metrics, this would sometimes cause a warning with the sqlite transport trying to be closed on a different thread (as it was getting cleaned up by `__del__`). to resolve this, the sqlite transport is now closed directly after use in `get_local_accounts()`