### PR TITLE
feat(client): stream invites

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/python-3/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/python-3/.devcontainer/base.Dockerfile
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
-ARG VARIANT="3.9"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+ARG VARIANT="3.10"
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="16"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,9 @@
 		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
+		"python.linting.pylintArgs": [
+			"--max-line-length=120"
+		],
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
 		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
 		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -6,16 +6,12 @@ services:
       POSTGRES_DB: speckle2_test
       POSTGRES_PASSWORD: speckle
       POSTGRES_USER: speckle
-      # ports:
-      #   - "5432:5432"
     network_mode: host
   redis:
     image: cimg/redis:6.2
-    # ports:
-    #   - "6379:6379"
     network_mode: host
   speckle-server:
-    image: speckle/speckle-server
+    image: speckle/speckle-server:latest
     command: ["bash", "-c", "/wait && node bin/www"]
     environment:
       POSTGRES_URL: "localhost"
@@ -28,8 +24,6 @@ services:
       CANONICAL_URL: "http://localhost:3000"
       WAIT_HOSTS: localhost:5432, localhost:6379
       DISABLE_FILE_UPLOADS: "true"
-    # ports:
-    #   - "3000:3000"
     network_mode: host
 
   specklepy:

--- a/specklepy/api/client.py
+++ b/specklepy/api/client.py
@@ -160,8 +160,25 @@ class SpeckleClient:
         return self.httpclient.execute(query)
 
     def _init_resources(self) -> None:
-        self.stream = stream.Resource(
+        self.server = server.Resource(
             account=self.account, basepath=self.url, client=self.httpclient
+        )
+        server_version = None
+        try:
+            server_version = self.server.version()
+        except:
+            pass
+        self.user = user.Resource(
+            account=self.account,
+            basepath=self.url,
+            client=self.httpclient,
+            server_version=server_version,
+        )
+        self.stream = stream.Resource(
+            account=self.account,
+            basepath=self.url,
+            client=self.httpclient,
+            server_version=server_version,
         )
         self.commit = commit.Resource(
             account=self.account, basepath=self.url, client=self.httpclient
@@ -170,12 +187,6 @@ class SpeckleClient:
             account=self.account, basepath=self.url, client=self.httpclient
         )
         self.object = object.Resource(
-            account=self.account, basepath=self.url, client=self.httpclient
-        )
-        self.server = server.Resource(
-            account=self.account, basepath=self.url, client=self.httpclient
-        )
-        self.user = user.Resource(
             account=self.account, basepath=self.url, client=self.httpclient
         )
         self.subscribe = subscriptions.Resource(

--- a/specklepy/api/models.py
+++ b/specklepy/api/models.py
@@ -110,6 +110,23 @@ class User(BaseModel):
         return self.__repr__()
 
 
+class PendingStreamCollaborator(BaseModel):
+    id: Optional[str]
+    inviteId: Optional[str]
+    streamId: Optional[str]
+    streamName: Optional[str]
+    title: Optional[str]
+    role: Optional[str]
+    invitedBy: Optional[User]
+    user: Optional[User]
+
+    def __repr__(self):
+        return f"PendingStreamCollaborator( inviteId: {self.inviteId}, streamId: {self.streamId}, role: {self.role}, title: {self.title}, invitedBy: {self.user.name if self.user else None})"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+
 class Activity(BaseModel):
     actionType: Optional[str]
     info: Optional[dict]

--- a/specklepy/api/models.py
+++ b/specklepy/api/models.py
@@ -119,6 +119,7 @@ class PendingStreamCollaborator(BaseModel):
     role: Optional[str]
     invitedBy: Optional[User]
     user: Optional[User]
+    token: Optional[str]
 
     def __repr__(self):
         return f"PendingStreamCollaborator( inviteId: {self.inviteId}, streamId: {self.streamId}, role: {self.role}, title: {self.title}, invitedBy: {self.user.name if self.user else None})"

--- a/specklepy/api/models.py
+++ b/specklepy/api/models.py
@@ -3,10 +3,10 @@
 #   timestamp: 2020-11-17T14:33:13+00:00
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 
-from pydantic import BaseModel
+from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 
 class Collaborator(BaseModel):
@@ -133,7 +133,7 @@ class ActivityCollection(BaseModel):
     cursor: Optional[datetime]
 
     def __repr__(self) -> str:
-        return f"ActivityCollection( totalCount: {self.totalCount}, items: {len(self.items) if self.items else 0}, cursor: {self.cursor.isoformat()} )"
+        return f"ActivityCollection( totalCount: {self.totalCount}, items: {len(self.items) if self.items else 0}, cursor: {self.cursor.isoformat() if self.cursor else None} )"
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/specklepy/api/resource.py
+++ b/specklepy/api/resource.py
@@ -1,7 +1,7 @@
 from graphql import DocumentNode
 from specklepy.api.credentials import Account
 from specklepy.transports.sqlite import SQLiteTransport
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from gql.client import Client
 from gql.transport.exceptions import TransportQueryError
 from specklepy.logging.exceptions import GraphQLException, SpeckleException
@@ -15,12 +15,14 @@ class ResourceBase(object):
         basepath: str,
         client: Client,
         name: str,
+        server_version: Optional[Tuple[Any, ...]] = None,
     ) -> None:
         self.account = account
         self.basepath = basepath
         self.client = client
         self.name = name
-        self.schema: Union[Type, None] = None
+        self.server_version = server_version
+        self.schema: Optional[Type] = None
 
     def _step_into_response(self, response: dict, return_type: Union[str, List, None]):
         """Step into the dict to get the relevant data"""
@@ -33,8 +35,10 @@ class ResourceBase(object):
                 response = response[key]
             return response
 
-    def _parse_response(self, response: Union[dict, list], schema=None):
+    def _parse_response(self, response: Union[dict, list, None], schema=None):
         """Try to create a class instance from the response"""
+        if response is None:
+            return None
         if isinstance(response, list):
             return [self._parse_response(response=r, schema=schema) for r in response]
         if schema:

--- a/specklepy/api/resource.py
+++ b/specklepy/api/resource.py
@@ -1,8 +1,8 @@
+from graphql import DocumentNode
 from specklepy.api.credentials import Account
 from specklepy.transports.sqlite import SQLiteTransport
-from typing import Dict, List
+from typing import Any, Dict, List, Type, Union
 from gql.client import Client
-from gql.gql import gql
 from gql.transport.exceptions import TransportQueryError
 from specklepy.logging.exceptions import GraphQLException, SpeckleException
 from specklepy.serialization.base_object_serializer import BaseObjectSerializer
@@ -15,27 +15,25 @@ class ResourceBase(object):
         basepath: str,
         client: Client,
         name: str,
-        methods: list,
     ) -> None:
         self.account = account
         self.basepath = basepath
         self.client = client
         self.name = name
-        self.methods = methods
-        self.schema = None
+        self.schema: Union[Type, None] = None
 
-    def _step_into_response(self, response: dict, return_type: str or List):
+    def _step_into_response(self, response: dict, return_type: Union[str, List, None]):
         """Step into the dict to get the relevant data"""
         if return_type is None:
             return response
-        elif isinstance(return_type, str):
+        if isinstance(return_type, str):
             return response[return_type]
-        elif isinstance(return_type, List):
+        if isinstance(return_type, List):
             for key in return_type:
                 response = response[key]
             return response
 
-    def _parse_response(self, response: dict or list, schema=None):
+    def _parse_response(self, response: Union[dict, list], schema=None):
         """Try to create a class instance from the response"""
         if isinstance(response, list):
             return [self._parse_response(response=r, schema=schema) for r in response]
@@ -52,26 +50,26 @@ class ResourceBase(object):
 
     def make_request(
         self,
-        query: gql,
+        query: DocumentNode,
         params: Dict = None,
-        return_type: str or List = None,
+        return_type: Union[str, List, None] = None,
         schema=None,
         parse_response: bool = True,
-    ) -> Dict or GraphQLException:
+    ) -> Any:
         """Executes the GraphQL query"""
         try:
             response = self.client.execute(query, variable_values=params)
-        except Exception as e:
-            if isinstance(e, TransportQueryError):
+        except Exception as ex:
+            if isinstance(ex, TransportQueryError):
                 return GraphQLException(
-                    message=f"Failed to execute the GraphQL {self.name} request. Errors: {e.errors}",
-                    errors=e.errors,
-                    data=e.data,
+                    message=f"Failed to execute the GraphQL {self.name} request. Errors: {ex.errors}",
+                    errors=ex.errors,
+                    data=ex.data,
                 )
             else:
                 return SpeckleException(
-                    message=f"Failed to execute the GraphQL {self.name} request. Inner exception: {e}",
-                    exception=e,
+                    message=f"Failed to execute the GraphQL {self.name} request. Inner exception: {ex}",
+                    exception=ex,
                 )
 
         response = self._step_into_response(response=response, return_type=return_type)

--- a/specklepy/api/resources/__init__.py
+++ b/specklepy/api/resources/__init__.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import sys
-import inspect
 import pkgutil
 from importlib import import_module
 

--- a/specklepy/api/resources/branch.py
+++ b/specklepy/api/resources/branch.py
@@ -4,7 +4,6 @@ from specklepy.api.models import Branch
 from specklepy.logging import metrics
 
 NAME = "branch"
-METHODS = ["create"]
 
 
 class Resource(ResourceBase):
@@ -16,7 +15,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
         self.schema = Branch
 

--- a/specklepy/api/resources/commit.py
+++ b/specklepy/api/resources/commit.py
@@ -6,7 +6,6 @@ from specklepy.logging import metrics
 
 
 NAME = "commit"
-METHODS = []
 
 
 class Resource(ResourceBase):
@@ -18,7 +17,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
         self.schema = Commit
 

--- a/specklepy/api/resources/object.py
+++ b/specklepy/api/resources/object.py
@@ -4,7 +4,6 @@ from specklepy.api.resource import ResourceBase
 from specklepy.objects.base import Base
 
 NAME = "object"
-METHODS = []
 
 
 class Resource(ResourceBase):
@@ -16,7 +15,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
         self.schema = Base
 

--- a/specklepy/api/resources/server.py
+++ b/specklepy/api/resources/server.py
@@ -67,7 +67,8 @@ class Resource(ResourceBase):
         """Get the server version
 
         Returns:
-            Tuple(int) -- the server version
+            Tuple(int) -- the server version in the format (major, minor, patch, (tag, build))
+                          eg (2, 6, 3) for a stable build and (2, 6, 4, 'alpha', 4711) for alpha
         """
         # not tracking as it will be called along with other mutations / queries as a check
         query = gql(

--- a/specklepy/api/resources/server.py
+++ b/specklepy/api/resources/server.py
@@ -1,8 +1,10 @@
-from typing import Dict, List
+import re
+from typing import Dict, List, Tuple
 from gql import gql
 from specklepy.api.models import ServerInfo
 from specklepy.api.resource import ResourceBase
 from specklepy.logging import metrics
+from specklepy.logging.exceptions import GraphQLException
 
 
 NAME = "server"
@@ -59,6 +61,39 @@ class Resource(ResourceBase):
 
         return self.make_request(
             query=query, return_type="serverInfo", schema=ServerInfo
+        )
+
+    def version(self) -> Tuple[int]:
+        """Get the server version
+
+        Returns:
+            Tuple(int) -- the server version
+        """
+        # not tracking as it will be called along with other mutations / queries as a check
+        query = gql(
+            """
+            query Server {
+                serverInfo {
+                    version
+                }
+            }
+            """
+        )
+
+        ver = self.make_request(
+            query=query, return_type=["serverInfo", "version"], parse_response=False
+        )
+        if isinstance(ver, Exception):
+            raise GraphQLException(
+                f"Could not get server version for {self.basepath}", ver
+            )
+
+        # pylint: disable=consider-using-generator; (list comp is faster)
+        return tuple(
+            [
+                int(segment) if segment.isdigit() else segment
+                for segment in re.split(r"\.|-", ver)
+            ]
         )
 
     def apps(self) -> Dict:

--- a/specklepy/api/resources/server.py
+++ b/specklepy/api/resources/server.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 from gql import gql
 from specklepy.api.models import ServerInfo
 from specklepy.api.resource import ResourceBase
@@ -8,7 +8,6 @@ from specklepy.logging.exceptions import GraphQLException
 
 
 NAME = "server"
-METHODS = ["get", "apps"]
 
 
 class Resource(ResourceBase):
@@ -20,7 +19,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
 
     def get(self) -> ServerInfo:
@@ -63,12 +61,12 @@ class Resource(ResourceBase):
             query=query, return_type="serverInfo", schema=ServerInfo
         )
 
-    def version(self) -> Tuple[int]:
+    def version(self) -> Tuple[Any, ...]:
         """Get the server version
 
         Returns:
-            Tuple(int) -- the server version in the format (major, minor, patch, (tag, build))
-                          eg (2, 6, 3) for a stable build and (2, 6, 4, 'alpha', 4711) for alpha
+            tuple -- the server version in the format (major, minor, patch, (tag, build))
+                     eg (2, 6, 3) for a stable build and (2, 6, 4, 'alpha', 4711) for alpha
         """
         # not tracking as it will be called along with other mutations / queries as a check
         query = gql(
@@ -80,13 +78,12 @@ class Resource(ResourceBase):
             }
             """
         )
-
         ver = self.make_request(
             query=query, return_type=["serverInfo", "version"], parse_response=False
         )
         if isinstance(ver, Exception):
             raise GraphQLException(
-                f"Could not get server version for {self.basepath}", ver
+                f"Could not get server version for {self.basepath}", [ver]
             )
 
         # pylint: disable=consider-using-generator; (list comp is faster)

--- a/specklepy/api/resources/stream.py
+++ b/specklepy/api/resources/stream.py
@@ -13,7 +13,7 @@ NAME = "stream"
 class Resource(ResourceBase):
     """API Access class for streams"""
 
-    def __init__(self, account, basepath, client) -> None:
+    def __init__(self, account, basepath, client, server_version) -> None:
         super().__init__(
             account=account,
             basepath=basepath,

--- a/specklepy/api/resources/stream.py
+++ b/specklepy/api/resources/stream.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
-from gql import gql
 from typing import List
+from gql import gql
 from specklepy.logging import metrics
 from specklepy.api.models import ActivityCollection, Stream
 from specklepy.api.resource import ResourceBase
@@ -8,7 +8,6 @@ from specklepy.logging.exceptions import SpeckleException
 
 
 NAME = "stream"
-METHODS = ["list", "create", "get", "update", "delete", "search", "activity"]
 
 
 class Resource(ResourceBase):
@@ -20,7 +19,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
 
         self.schema = Stream

--- a/specklepy/api/resources/subscriptions.py
+++ b/specklepy/api/resources/subscriptions.py
@@ -1,16 +1,12 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 from functools import wraps
 from gql import gql
+from graphql import DocumentNode
 from specklepy.api.resource import ResourceBase
 from specklepy.api.resources.stream import Stream
 from specklepy.logging.exceptions import SpeckleException
 
 NAME = "subscribe"
-METHODS = [
-    "stream_added",
-    "stream_updated",
-    "stream_removed",
-]
 
 
 def check_wsclient(function):
@@ -35,7 +31,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
 
     @check_wsclient
@@ -109,15 +104,15 @@ class Resource(ResourceBase):
     @check_wsclient
     async def subscribe(
         self,
-        query: gql,
+        query: DocumentNode,
         params: Dict = None,
         callback: Callable = None,
-        return_type: str or List = None,
+        return_type: Union[str, List] = None,
         schema=None,
         parse_response: bool = True,
     ):
         # if self.client.transport.websocket is None:
-        #     TODO: add multiple subs to the same ws connection
+        # TODO: add multiple subs to the same ws connection
         async with self.client as session:
             async for res in session.subscribe(query, variable_values=params):
                 res = self._step_into_response(response=res, return_type=return_type)

--- a/specklepy/api/resources/user.py
+++ b/specklepy/api/resources/user.py
@@ -1,13 +1,12 @@
+from typing import List, Union
 from datetime import datetime, timezone
+from gql import gql
 from specklepy.logging import metrics
 from specklepy.logging.exceptions import SpeckleException
-from typing import List
-from gql import gql
 from specklepy.api.resource import ResourceBase
 from specklepy.api.models import ActivityCollection, User
 
 NAME = "user"
-METHODS = ["get", "search", "update", "activity"]
 
 
 class Resource(ResourceBase):
@@ -19,7 +18,6 @@ class Resource(ResourceBase):
             basepath=basepath,
             client=client,
             name=NAME,
-            methods=METHODS,
         )
         self.schema = User
 
@@ -55,7 +53,9 @@ class Resource(ResourceBase):
 
         return self.make_request(query=query, params=params, return_type="user")
 
-    def search(self, search_query: str, limit: int = 25) -> List[User]:
+    def search(
+        self, search_query: str, limit: int = 25
+    ) -> Union[List[User], SpeckleException]:
         """Searches for user by name or email. The search query must be at least 3 characters long
 
         Arguments:

--- a/specklepy/api/resources/user.py
+++ b/specklepy/api/resources/user.py
@@ -12,12 +12,13 @@ NAME = "user"
 class Resource(ResourceBase):
     """API Access class for users"""
 
-    def __init__(self, account, basepath, client) -> None:
+    def __init__(self, account, basepath, client, server_version) -> None:
         super().__init__(
             account=account,
             basepath=basepath,
             client=client,
             name=NAME,
+            server_version=server_version,
         )
         self.schema = User
 

--- a/specklepy/logging/exceptions.py
+++ b/specklepy/logging/exceptions.py
@@ -33,6 +33,14 @@ class GraphQLException(SpeckleException):
         return f"GraphQLException: {self.message}"
 
 
+class UnsupportedException(SpeckleException):
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)
+
+    def __str__(self) -> str:
+        return f"UnsupportedException: {self.message}"
+
+
 class SpeckleWarning(Warning):
     def __init__(self, *args: object) -> None:
         super().__init__(*args)

--- a/specklepy/logging/exceptions.py
+++ b/specklepy/logging/exceptions.py
@@ -1,8 +1,9 @@
-from typing import Any, List
+from typing import Any, List, Optional
 
 
 class SpeckleException(Exception):
     def __init__(self, message: str, exception: Exception = None) -> None:
+        super().__init__()
         self.message = message
         self.exception = exception
 
@@ -11,17 +12,19 @@ class SpeckleException(Exception):
 
 
 class SerializationException(SpeckleException):
-    def __init__(self, message: str, object: Any, exception: Exception = None) -> None:
-        super().__init__(message=message)
-        self.object = object
-        self.unhandled_type = type(object)
+    def __init__(self, message: str, obj: Any, exception: Exception = None) -> None:
+        super().__init__(message=message, exception=exception)
+        self.obj = obj
+        self.unhandled_type = type(obj)
 
     def __str__(self) -> str:
         return f"SpeckleException: Could not serialize object of type {self.unhandled_type}"
 
 
 class GraphQLException(SpeckleException):
-    def __init__(self, message: str, errors: List, data=None) -> None:
+    def __init__(
+        self, message: str, errors: Optional[List[Any]] = None, data=None
+    ) -> None:
         super().__init__(message=message)
         self.errors = errors
         self.data = data

--- a/specklepy/logging/metrics.py
+++ b/specklepy/logging/metrics.py
@@ -26,6 +26,7 @@ RECEIVE = "Receive"
 SEND = "Send"
 STREAM = "Stream Action"
 PERMISSION = "Permission Action"
+INVITE = "Invite Action"
 COMMIT = "Commit Action"
 BRANCH = "Branch Action"
 USER = "User Action"
@@ -79,6 +80,7 @@ def track(action: str, account: "Account" = None, custom_props: dict = None):
     except Exception as ex:
         # wrapping this whole thing in a try except as we never want a failure here to annoy users!
         LOG.error(f"Error queueing metrics request: {str(ex)}")
+
 
 def initialise_tracker(account: "Account" = None):
     global METRICS_TRACKER

--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -92,12 +92,19 @@ class _RegisteringBase:
     speckle_type: ClassVar[str]
     _type_registry: ClassVar[Dict[str, "Base"]] = {}
     _attr_types: ClassVar[Dict[str, Type]] = {}
+    # dict of chunkable props and their max chunk size
+    _chunkable: Dict[str, int] = {}
+    _chunk_size_default: int = 1000
+    _detachable: Set[str] = set()  # list of defined detachable props
+    _serialize_ignore: Set[str] = set()
 
     class Config:
         validate_assignment = True
 
     @classmethod
-    def get_registered_type(cls, speckle_type: str) -> Optional[Type["Base"]]:
+    def get_registered_type(
+        cls, speckle_type: str
+    ) -> Union["Base", Type["Base"], None]:
         """Get the registered type from the protected mapping via the `speckle_type`"""
         return cls._type_registry.get(speckle_type, None)
 
@@ -142,12 +149,7 @@ class Base(_RegisteringBase):
     id: Optional[str] = None
     totalChildrenCount: Optional[int] = None
     applicationId: Optional[str] = None
-    _units: str = None
-    # dict of chunkable props and their max chunk size
-    _chunkable: Dict[str, int] = {}
-    _chunk_size_default: int = 1000
-    _detachable: Set[str] = set()  # list of defined detachable props
-    _serialize_ignore: Set[str] = set()
+    _units: Union[str, None] = None
 
     def __init__(self, **kwargs) -> None:
         super().__init__()
@@ -378,6 +380,7 @@ class Base(_RegisteringBase):
         )
 
     def _handle_object_count(self, obj: Any, parsed: List) -> int:
+        # pylint: disable=isinstance-second-argument-not-valid-type
         count = 0
         if obj is None:
             return count
@@ -406,7 +409,7 @@ Base.update_forward_refs()
 
 
 class DataChunk(Base, speckle_type="Speckle.Core.Models.DataChunk"):
-    data: List[Any] = None
+    data: Union[List[Any], None] = None
 
     def __init__(self) -> None:
         super().__init__()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,13 @@ def client(host, user_dict):
 
 
 @pytest.fixture(scope="session")
+def second_client(host, second_user_dict):
+    client = SpeckleClient(host=host, use_ssl=False)
+    client.authenticate_with_token(second_user_dict["token"])
+    return client
+
+
+@pytest.fixture(scope="session")
 def sample_stream(client):
     stream = Stream(
         name="a sample stream for testing",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from contextlib import ExitStack as does_not_raise
 
 import pytest
@@ -111,6 +111,7 @@ class FrozenYoghurt(Base):
     add_ons: Optional[Dict[str, float]]  # dict item types won't be checked
     price: float = 0.0
     dietary: DietaryRestrictions
+    tag: Union[int, str]
 
 
 def test_type_checking() -> None:
@@ -120,6 +121,8 @@ def test_type_checking() -> None:
     order.price = "7"  # will get converted
     order.customer = "izzy"
     order.dietary = DietaryRestrictions.VEGAN
+    order.tag = "preorder"
+    order.tag = 4411
 
     with pytest.raises(SpeckleException):
         order.flavours = "not a list"
@@ -129,6 +132,8 @@ def test_type_checking() -> None:
         order.add_ons = ["sprinkles"]
     with pytest.raises(SpeckleException):
         order.dietary = "no nuts plz"
+    with pytest.raises(SpeckleException):
+        order.tag = ["tag01", "tag02"]
 
     order.add_ons = {"sprinkles": 0.2, "chocolate": 1.0}
     order.flavours = ["strawberry", "lychee", "peach", "pineapple"]
@@ -137,7 +142,7 @@ def test_type_checking() -> None:
 
 
 def test_cached_deserialization() -> None:
-    material = Base(color="blue", opacity=.5)
+    material = Base(color="blue", opacity=0.5)
 
     a = Base(name="a")
     a["@material"] = material

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import pytest
 from specklepy.api.models import ServerInfo
+from specklepy.api.client import SpeckleClient
 
 
 class TestServer:
@@ -12,7 +13,7 @@ class TestServer:
             "lifespan": 9001,
         }
 
-    def test_server_get(self, client):
+    def test_server_get(self, client: SpeckleClient):
         server = client.server.get()
 
         assert isinstance(server, ServerInfo)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,7 +18,14 @@ class TestServer:
 
         assert isinstance(server, ServerInfo)
 
-    def test_server_apps(self, client):
+    def test_server_version(self, client: SpeckleClient):
+        version = client.server.version()
+
+        assert isinstance(version, tuple)
+        assert isinstance(version[0], int)
+        assert len(version) >= 3
+
+    def test_server_apps(self, client: SpeckleClient):
         apps = client.server.apps()
 
         assert isinstance(apps, list)


### PR DESCRIPTION
adds support for new stream invite flow that is being introduced on Speckle Server >= 2.6.4 (double check this)

this includes additions to `stream` including:
- `get_all_pending_invites`
- `get_pending_invite`
- `invite`
- `invite_batch`
- `invite_cancel`
- `invite_use`
- `update_permission`
and test for all of these

main changes are here:
https://github.com/specklesystems/specklepy/pull/202/files#diff-fac1f2e2b8f6d92364d9669dcc6e87686845c6ba33a2de2a0cfb8e071e99f637

tests are here:
https://github.com/specklesystems/specklepy/pull/202/files#diff-ea0709cafe72641d2626e0ac259bd85f09f16496ba240cee1e25589f64ced848


to check:
- [x] how are you meant to get a stream invite id that you've already created? the get invite queries only return invites addressed to you
  - query from within the stream endpoint!
- [x] poss bug in server: only server admins seem to be able to batch create _stream_ invites
  - correct, for now only admins can batch invite

closes #201 and more!

similar thing may need to happen here
https://github.com/specklesystems/speckle-sharp/pull/1431