### PR TITLE
Base: accept None units

### DIFF
--- a/specklepy/objects/base.py
+++ b/specklepy/objects/base.py
@@ -318,8 +318,8 @@ class Base(_RegisteringBase):
 
     @units.setter
     def units(self, value: str):
-        units = get_units_from_string(value)
-        if units:
+        units, valid_units = get_units_from_string(value)
+        if valid_units:
             self._units = units
 
     def get_member_names(self) -> List[str]:

--- a/specklepy/objects/units.py
+++ b/specklepy/objects/units.py
@@ -1,3 +1,4 @@
+from typing import Union, Tuple
 from warnings import warn
 from specklepy.logging.exceptions import SpeckleException, SpeckleWarning
 
@@ -29,17 +30,19 @@ UNITS_ENCODINGS = {
 }
 
 
-def get_units_from_string(unit: str):
+def get_units_from_string(unit: Union[str, None]) -> Tuple[Union[str, None], bool]:
+    if unit is None:
+        return None, True
     if not isinstance(unit, str):
         warn(
             f"Invalid units: expected type str but received {type(unit)} ({unit}). Skipping - no units will be set.",
             SpeckleWarning,
         )
-        return
+        return None, False
     unit = str.lower(unit)
     for name, alternates in UNITS_STRINGS.items():
         if unit in alternates:
-            return name
+            return name, True
 
     raise SpeckleException(
         message=f"Could not understand what unit {unit} is referring to. Please enter a valid unit (eg {UNITS})."

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -85,9 +85,11 @@ def test_setting_units():
     with pytest.raises(SpeckleException):
         b.units = "big"
 
-    b.units = None  # invalid args are skipped
-    b.units = 7
+    b.units = 7  # invalid args are skipped
     assert b.units == "ft"
+
+    b.units = None  # None should be a valid arg
+    assert b.units == None
 
 
 def test_base_of_custom_speckle_type() -> None:


### PR DESCRIPTION
Attempts to fix #210.

Allow setting `self.units = None` in Base.

Add test to capture the expected behavior.