### PR TITLE
fix: update minimum required version of pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.2, <4.0"
-pydantic = "^1.8.2"
+pydantic = "^1.9"
 appdirs = "^1.4.4"
 gql = {extras = ["requests", "websockets"], version = "^3.3.0"}
 ujson = "^5.3.0"


### PR DESCRIPTION
## Description & motivation

In #228 `specklepy.transports.abstract_transport` changed `from pydantic.main import Extra` to `from pydantic.config import Extra`. This change requires `pydantic>=1.9`.

## Changes:

Updates the minimum required version of `pydantic` given in `pyproject.toml` to `pydantic^1.9`.