### PR TITLE
Typo fix in properties.py

### DIFF
--- a/src/specklepy/objects/structural/properties.py
+++ b/src/specklepy/objects/structural/properties.py
@@ -5,7 +5,7 @@ from specklepy.objects.base import Base
 from specklepy.objects.structural.axis import Axis
 from specklepy.objects.structural.materials import StructuralMaterial
 
-STRUCTURAL_PROPERTY = "Objectives.Structural.Properties"
+STRUCTURAL_PROPERTY = "Objects.Structural.Properties"
 
 
 class MemberType(int, Enum):


### PR DESCRIPTION
Fix: Typo fix of `STRUCTURAL PROPERTY` variable in https://github.com/specklesystems/specklepy/blob/main/src/specklepy/objects/structural/properties.py#L8

## Description & motivation

Tiny bug with big consequences. All property objects will not be properly recognized and will be deserialized to a `Base` object. This gives issues in further conversion for our case, where we convert an analytical Revit model from Speckle to Python.

## Changes:

Fix typo

## To-do before merge:

Nothing, as far as I can see, **small patch would be much appreciated!** :)

## Validation of changes:

Fixed the typo locally, which allows me to convert a full structural model from Speckle to Python. I tested with a stream of an analytical Revit model used in of your tutorials: https://speckle.xyz/streams/bf8c36d0d2/commits/68269d458f

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
