### PR TITLE
Fix: Interoperability from Revit analytical to specklepy structural

### DIFF
--- a/src/specklepy/api/models.py
+++ b/src/specklepy/api/models.py
@@ -150,7 +150,7 @@ class PendingStreamCollaborator(BaseModel):
 
 
 class Activity(BaseModel):
-    actionType: Optional[str]
+    actionType: Optional[int]
     info: Optional[dict]
     userId: Optional[str]
     streamId: Optional[str]

--- a/src/specklepy/api/models.py
+++ b/src/specklepy/api/models.py
@@ -150,7 +150,7 @@ class PendingStreamCollaborator(BaseModel):
 
 
 class Activity(BaseModel):
-    actionType: Optional[int]
+    actionType: Optional[str]
     info: Optional[dict]
     userId: Optional[str]
     streamId: Optional[str]

--- a/src/specklepy/objects/structural/axis.py
+++ b/src/specklepy/objects/structural/axis.py
@@ -6,5 +6,5 @@ from specklepy.objects.geometry import Plane
 
 class Axis(Base, speckle_type="Objects.Structural.Geometry.Axis"):
     name: Optional[str] = None
-    axisType: Optional[str] = None
+    axisType: Optional[int] = None
     plane: Optional[Plane] = None

--- a/src/specklepy/objects/structural/properties.py
+++ b/src/specklepy/objects/structural/properties.py
@@ -90,7 +90,7 @@ class Property(Base, speckle_type=STRUCTURAL_PROPERTY):
     name: Optional[str] = None
 
 
-class SectionProfile(Base, speckle_type=STRUCTURAL_PROPERTY + ".SectionProfile"):
+class SectionProfile(Base, speckle_type=STRUCTURAL_PROPERTY + ".Profiles.SectionProfile"):
     name: Optional[str] = None
     shapeType: Optional[ShapeType] = None
     area: float = 0.0


### PR DESCRIPTION
## Description & motivation

Update `speckle_type` of `SectionProfile` to match C#, update type hints with C# Enum values to int.

For the SectionProfile, a separate static variable e.g. STRUCTURAL_PROFILE could be created later, I now just made an easy fix. For the enumeration attributes, I believe they should be integer, as e.g. Revit pushes them as integers, not strings.

## Changes 

Section profile fix allows to properly deserialize `SectionProfile` objects.
The type hint fixes allow to properly receive the `Axis` and `Activity` objects.

## Validation of changes:

Deserialized Analytical Revit test streams with the proposed changes, which then works.

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
