### PR TITLE
Initial implementation of traversal function in specklepy

### DIFF
--- a/src/specklepy/objects/graph_traversal/traversal.py
+++ b/src/specklepy/objects/graph_traversal/traversal.py
@@ -1,0 +1,87 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Any, Collection, Generator, Iterable, Iterator, List, Optional, Set, final
+from specklepy.objects import Base
+
+
+class AbstractTraversalRule(ABC):
+
+    @abstractmethod
+    def get_members_to_traverse(self, o: Base) -> Set[str]:
+        return []
+
+    @abstractmethod
+    def does_rule_hold(self, o: Base) -> bool:
+        return True
+
+@final
+class DefaultRule(AbstractTraversalRule):
+
+    def get_members_to_traverse(self, _) -> Set[str]:
+        return set()
+
+    def does_rule_hold(self, _) -> bool:
+        return True
+
+@final
+@dataclass(frozen=True, slots=True)
+class TraversalContext:
+    current: Base
+    member_name: Optional[str] = None
+    parent: Optional["TraversalContext"] = None
+
+@final
+@dataclass(frozen=True, slots=True)
+class GraphTraversal:
+
+    _rules: List[AbstractTraversalRule]
+
+    def traverse(self, root: Base) -> Iterator[TraversalContext]:
+        stack: List[TraversalContext] = []
+
+        stack.append(TraversalContext(root))
+
+        while len(stack) > 0:
+            head = stack.pop()
+            yield head
+
+            current = head.current
+            active_rule = self._get_active_rule_or_default_rule(current)
+            members_to_traverse = active_rule.get_members_to_traverse(current)
+            for child_prop in members_to_traverse:
+                self.traverse_member_to_stack(stack, current[child_prop], child_prop, head)
+            
+    @staticmethod
+    def traverse_member_to_stack(stack: List[TraversalContext], value: Any, member_name: Optional[str] = None, parent: Optional[TraversalContext] = None):
+        if isinstance(value, Base):
+            stack.append(TraversalContext(value, member_name, parent))
+        elif isinstance(value, list):
+            for obj in value:
+                GraphTraversal.traverse_member_to_stack(stack, obj, member_name, parent)
+        elif isinstance(value, dict):
+            for obj in value.values():
+                GraphTraversal.traverse_member_to_stack(stack, obj, member_name, parent)
+
+    def _get_active_rule_or_default_rule(self, o: Base) -> AbstractTraversalRule:
+        return self._get_active_rule(o) or DefaultRule()
+
+    def _get_active_rule(self, o: Base) -> Optional[AbstractTraversalRule]:
+        for rule in self._rules:
+            if rule.does_rule_hold(o):
+                return rule
+        return None
+
+@final
+@dataclass(slots=True)
+class TraversalRule(AbstractTraversalRule):
+    _conditions: Collection[Callable[[Base], bool]]
+    _members_to_traverse: Callable[[Base], Iterable[str]]
+
+    def get_members_to_traverse(self, o: Base) -> Set[str]:
+        return set(self._members_to_traverse(o))
+
+    def does_rule_hold(self, o: Base) -> bool:
+        for condition in self._conditions:
+            if(condition(o)):
+                return True
+        return False

--- a/src/specklepy/objects/graph_traversal/traversal.py
+++ b/src/specklepy/objects/graph_traversal/traversal.py
@@ -1,17 +1,7 @@
-from typing import (
-    Any,
-    Callable,
-    Collection,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    final,
-)
+from typing import Any, Callable, Collection, Iterable, Iterator, List, Optional, Set
 
 from attr import define
-from typing_extensions import Protocol
+from typing_extensions import Protocol, final
 
 from specklepy.objects import Base
 

--- a/src/specklepy/objects/graph_traversal/traversal.py
+++ b/src/specklepy/objects/graph_traversal/traversal.py
@@ -6,12 +6,12 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Protocol,
     Set,
     final,
 )
 
 from attr import define
+from typing_extensions import Protocol
 
 from specklepy.objects import Base
 

--- a/src/specklepy/objects/graph_traversal/traversal.py
+++ b/src/specklepy/objects/graph_traversal/traversal.py
@@ -16,7 +16,7 @@ from attr import define
 from specklepy.objects import Base
 
 
-class TraversalRule(Protocol):
+class ITraversalRule(Protocol):
     def get_members_to_traverse(self, o: Base) -> Set[str]:
         """Get the members to traverse."""
         pass
@@ -51,7 +51,7 @@ class TraversalContext:
 @define(slots=True, frozen=True)
 class GraphTraversal:
 
-    _rules: List[TraversalRule]
+    _rules: List[ITraversalRule]
 
     def traverse(self, root: Base) -> Iterator[TraversalContext]:
         stack: List[TraversalContext] = []
@@ -86,10 +86,10 @@ class GraphTraversal:
             for obj in value.values():
                 GraphTraversal.traverse_member_to_stack(stack, obj, member_name, parent)
 
-    def _get_active_rule_or_default_rule(self, o: Base) -> TraversalRule:
+    def _get_active_rule_or_default_rule(self, o: Base) -> ITraversalRule:
         return self._get_active_rule(o) or _default_rule
 
-    def _get_active_rule(self, o: Base) -> Optional[TraversalRule]:
+    def _get_active_rule(self, o: Base) -> Optional[ITraversalRule]:
         for rule in self._rules:
             if rule.does_rule_hold(o):
                 return rule
@@ -98,7 +98,7 @@ class GraphTraversal:
 
 @final
 @define(slots=True, frozen=True)
-class TraversalRuleImpl:
+class TraversalRule:
     _conditions: Collection[Callable[[Base], bool]]
     _members_to_traverse: Callable[[Base], Iterable[str]]
 

--- a/tests/unit/test_graph_traversal.py
+++ b/tests/unit/test_graph_traversal.py
@@ -1,13 +1,12 @@
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 from unittest import TestCase
-
-from attrs import define
 
 from specklepy.objects import Base
 from specklepy.objects.graph_traversal.traversal import GraphTraversal, TraversalRule
 
 
-@define
+@dataclass()
 class TraversalMock(Base):
     child: Optional[Base]
     list_children: List[Base]

--- a/tests/unit/test_graph_traversal.py
+++ b/tests/unit/test_graph_traversal.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from unittest import TestCase
+from specklepy.objects import Base
+from specklepy.objects.graph_traversal.traversal import TraversalRule, GraphTraversal
+
+@dataclass()
+class TraversalMock(Base):
+    child: Optional[Base]
+    list_children: List[Base]
+    dict_children: Dict[str, Base]
+
+class GraphTraversalTests(TestCase):
+
+    def test_traverse_list_members(self):
+        traverse_lists_rule = TraversalRule(
+            [lambda _ : True],
+            lambda x : [item for item in x.get_member_names() if isinstance(getattr(x, item, None), list)]
+        )
+
+        expected_traverse = Base()
+        expected_traverse.id = "List Member"
+
+        expected_ignore = Base()
+        expected_ignore.id = "Not List Member"
+
+        test_case = TraversalMock(
+            list_children = [expected_traverse],
+            dict_children = {"myprop" : expected_ignore},
+            child = expected_ignore
+        )
+
+        ret = [context.current for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)]
+
+        self.assertCountEqual(ret, [test_case, expected_traverse])
+        self.assertNotIn(expected_ignore, ret)
+        self.assertEqual(len(ret), 2)
+
+    def test_traverse_dict_members(self):
+        traverse_lists_rule = TraversalRule(
+            [lambda _ : True],
+            lambda x : [item for item in x.get_member_names() if isinstance(getattr(x, item, None), dict)]
+        )
+
+        expected_traverse = Base()
+        expected_traverse.id = "Dict Member"
+
+        expected_ignore = Base()
+        expected_ignore.id = "Not Dict Member"
+
+        test_case = TraversalMock(
+            list_children = [expected_ignore],
+            dict_children = {"myprop" : expected_traverse},
+            child = expected_ignore
+        )
+
+        ret = [context.current for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)]
+
+        self.assertCountEqual(ret, [test_case, expected_traverse])
+        self.assertNotIn(expected_ignore, ret)
+        self.assertEqual(len(ret), 2)
+
+    def test_traverse_dynamic(self):
+        traverse_lists_rule = TraversalRule(
+            [lambda _ : True],
+            lambda x : x.get_dynamic_member_names()
+        )
+
+        expected_traverse = Base()
+        expected_traverse.id = "List Member"
+
+        expected_ignore = Base()
+        expected_ignore.id = "Not List Member"
+
+        test_case = TraversalMock(
+            child = expected_ignore,
+            list_children = [expected_ignore],
+            dict_children = {"myprop" : expected_ignore},
+        )
+        test_case["dynamicChild"] = expected_traverse
+        test_case["dynamicListChild"] = [expected_traverse]
+
+        ret = [context.current for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)]
+
+        self.assertCountEqual(ret, [test_case, expected_traverse, expected_traverse])
+        self.assertNotIn(expected_ignore, ret)
+        self.assertEqual(len(ret), 3)

--- a/tests/unit/test_graph_traversal.py
+++ b/tests/unit/test_graph_traversal.py
@@ -1,21 +1,28 @@
-from dataclasses import dataclass
 from typing import Dict, List, Optional
 from unittest import TestCase
-from specklepy.objects import Base
-from specklepy.objects.graph_traversal.traversal import TraversalRule, GraphTraversal
 
-@dataclass()
+from attrs import define
+
+from specklepy.objects import Base
+from specklepy.objects.graph_traversal.traversal import GraphTraversal, TraversalRule
+
+
+@define
 class TraversalMock(Base):
     child: Optional[Base]
     list_children: List[Base]
     dict_children: Dict[str, Base]
 
-class GraphTraversalTests(TestCase):
 
+class GraphTraversalTests(TestCase):
     def test_traverse_list_members(self):
         traverse_lists_rule = TraversalRule(
-            [lambda _ : True],
-            lambda x : [item for item in x.get_member_names() if isinstance(getattr(x, item, None), list)]
+            [lambda _: True],
+            lambda x: [
+                item
+                for item in x.get_member_names()
+                if isinstance(getattr(x, item, None), list)
+            ],
         )
 
         expected_traverse = Base()
@@ -25,12 +32,15 @@ class GraphTraversalTests(TestCase):
         expected_ignore.id = "Not List Member"
 
         test_case = TraversalMock(
-            list_children = [expected_traverse],
-            dict_children = {"myprop" : expected_ignore},
-            child = expected_ignore
+            list_children=[expected_traverse],
+            dict_children={"myprop": expected_ignore},
+            child=expected_ignore,
         )
 
-        ret = [context.current for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)]
+        ret = [
+            context.current
+            for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)
+        ]
 
         self.assertCountEqual(ret, [test_case, expected_traverse])
         self.assertNotIn(expected_ignore, ret)
@@ -38,8 +48,12 @@ class GraphTraversalTests(TestCase):
 
     def test_traverse_dict_members(self):
         traverse_lists_rule = TraversalRule(
-            [lambda _ : True],
-            lambda x : [item for item in x.get_member_names() if isinstance(getattr(x, item, None), dict)]
+            [lambda _: True],
+            lambda x: [
+                item
+                for item in x.get_member_names()
+                if isinstance(getattr(x, item, None), dict)
+            ],
         )
 
         expected_traverse = Base()
@@ -49,12 +63,15 @@ class GraphTraversalTests(TestCase):
         expected_ignore.id = "Not Dict Member"
 
         test_case = TraversalMock(
-            list_children = [expected_ignore],
-            dict_children = {"myprop" : expected_traverse},
-            child = expected_ignore
+            list_children=[expected_ignore],
+            dict_children={"myprop": expected_traverse},
+            child=expected_ignore,
         )
 
-        ret = [context.current for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)]
+        ret = [
+            context.current
+            for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)
+        ]
 
         self.assertCountEqual(ret, [test_case, expected_traverse])
         self.assertNotIn(expected_ignore, ret)
@@ -62,8 +79,7 @@ class GraphTraversalTests(TestCase):
 
     def test_traverse_dynamic(self):
         traverse_lists_rule = TraversalRule(
-            [lambda _ : True],
-            lambda x : x.get_dynamic_member_names()
+            [lambda _: True], lambda x: x.get_dynamic_member_names()
         )
 
         expected_traverse = Base()
@@ -73,14 +89,17 @@ class GraphTraversalTests(TestCase):
         expected_ignore.id = "Not List Member"
 
         test_case = TraversalMock(
-            child = expected_ignore,
-            list_children = [expected_ignore],
-            dict_children = {"myprop" : expected_ignore},
+            child=expected_ignore,
+            list_children=[expected_ignore],
+            dict_children={"myprop": expected_ignore},
         )
         test_case["dynamicChild"] = expected_traverse
         test_case["dynamicListChild"] = [expected_traverse]
 
-        ret = [context.current for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)]
+        ret = [
+            context.current
+            for context in GraphTraversal([traverse_lists_rule]).traverse(test_case)
+        ]
 
         self.assertCountEqual(ret, [test_case, expected_traverse, expected_traverse])
         self.assertNotIn(expected_ignore, ret)


### PR DESCRIPTION
Implemented Traversal Function MVP in PY see https://github.com/specklesystems/speckle-sharp/issues/1732

TODO before merge:
- [ ] FIX Python <3.10 (oops I did it again, using a newer python version without checking... I can fix this)
- [ ] Check python class structure/decorators
I've tried to match the C# implementation as close as possible, and I only mostly know what I'm doing in py.
- [ ] Check python styling is acceptable
- [ ] Check where the traversal.py module should be? In C# land it's in [`Speckle.Core.Models.GraphTraversal`](https://github.com/specklesystems/speckle-sharp/tree/release/2.12/Core/Core/Models/GraphTraversal) but I noticed that `Models` doesn't exist, so I've put it in `objects/graph_traversal` for now, there may be a better place.
- [ ] I haven't reflected the builder pattern for the [`RuleBuilder`](https://github.com/specklesystems/speckle-sharp/blob/release/2.12/Core/Core/Models/GraphTraversal/RuleBuilder.cs), is the current implementation using lambdas ok?