### PR TITLE
Fix: Add AxisType and fix its type in Axis

### DIFF
--- a/src/specklepy/objects/structural/__init__.py
+++ b/src/specklepy/objects/structural/__init__.py
@@ -6,7 +6,10 @@ from specklepy.objects.structural.analysis import (
     ModelSettings,
     ModelUnits,
 )
-from specklepy.objects.structural.axis import Axis
+from specklepy.objects.structural.axis import (
+    AxisType,
+    Axis
+)
 from specklepy.objects.structural.geometry import (
     Element1D,
     Element2D,
@@ -82,6 +85,7 @@ __all__ = [
     "ElementType1D",
     "ElementType2D",
     "ElementType3D",
+    "AxisType",
     "Axis",
     "Node",
     "Restraint",

--- a/src/specklepy/objects/structural/axis.py
+++ b/src/specklepy/objects/structural/axis.py
@@ -1,10 +1,17 @@
 from typing import Optional
+from enum import Enum
 
 from specklepy.objects.base import Base
 from specklepy.objects.geometry import Plane
 
 
+class AxisType(int, Enum):
+    Cartesian = 0
+    Cylindrical = 1
+    Spherical = 2
+
+
 class Axis(Base, speckle_type="Objects.Structural.Geometry.Axis"):
     name: Optional[str] = None
-    axisType: Optional[str] = None
+    axisType: Optional[AxisType] = None
     plane: Optional[Plane] = None


### PR DESCRIPTION
## Description & motivation

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

We encountered a bug where in Speckle, the AxisType is set as 0, so an `int`, but when we try to receive this commit in `specklepy`, we get the following error: 
`SpeckleException: Cannot set 'Axis.axisType':it expects type 'typing.Optional[str]',but received type 'int'`

I'm not sure why it would ever be string actually. It should be an Enum. For `LoadAxisType`, this is implemented correctly, so I have implemented it almost the same way for `Axis`. 

This error showed up when we switched from using a lot of our own custom Speckle structural classes to those that have been added to `specklepy`.

We really need this fix to be able to retrieve anything in Speckle at this point, so it would be great if it could be merged and released relatively soon.

## Changes:

- Added AxisType Enum class in `axis.py`.
- Set `Optional[AxisType]` as the type for `axisType` in the `Axis` class.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

