### PR TITLE
fix: `invite_batch` failing where `emails` or `user_ids` is not provided

### DIFF
--- a/src/specklepy/api/resources/stream.py
+++ b/src/specklepy/api/resources/stream.py
@@ -567,15 +567,16 @@ class Resource(ResourceBase):
 
         email_invites = [
             {"streamId": stream_id, "message": message, "email": email}
-            for email in emails
-            if emails is not None
+            for email in (emails if emails is not None else [])
+            if email is not None
         ]
 
         user_invites = [
             {"streamId": stream_id, "message": message, "userId": user_id}
-            for user_id in user_ids
-            if user_ids is not None
+            for user_id in (user_ids if user_ids is not None else []) 
+            if user_id is not None
         ]
+
 
         params = {"input": [*email_invites, *user_invites]}
 


### PR DESCRIPTION
## Description & motivation

stream.invite_batch allows for a list of emails or user_ids to be invited to a stream. The existing code doesn't check for the default None type prior to the conversion of each to user invite objects

## Changes:

each List builder `user_invites` and `email_invites` includes a None type check before iteration. 

The existing code was seemingly performing the None check on each list as a filter. This fails as the list iteration is already attempted before hitting the filter.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.