### PR TITLE
Fix: also suppress TypeError during type checking.

### DIFF
--- a/src/specklepy/objects/base.py
+++ b/src/specklepy/objects/base.py
@@ -307,7 +307,7 @@ def _validate_type(t: Optional[type], value: Any) -> Tuple[bool, Any]:
     if isinstance(value, t):
         return True, value
 
-    with contextlib.suppress(ValueError):
+    with contextlib.suppress(ValueError, TypeError):
         if t is float and value is not None:
             return True, float(value)
         # TODO: dafuq, i had to add this not list check

--- a/tests/unit/test_type_validation.py
+++ b/tests/unit/test_type_validation.py
@@ -107,6 +107,8 @@ fake_bases = [FakeBase("foo"), FakeBase("bar")]
             fake_bases,
         ),
         (List["int"], [2, 3, 4], True, [2, 3, 4]),
+        (Union[float, Dict[str, float]], {"foo": 1, "bar": 2}, True, {"foo": 1.0, "bar": 2.0}),
+        (Union[float, Dict[str, float]], {"foo": "bar"}, False, {"foo": "bar"}),
     ],
 )
 def test_validate_type(


### PR DESCRIPTION
## Description & motivation

Currently an error is raised in below line, when an attempt is made to convert a given value to a float. In my case, this is a problem when I have a Union type hint that includes float, e.g. `Union[int, float, dict]`. During type checking, an iteration will be made over the types within the Union. Then, when the value is a dictionary, it will give a TypeError, which is currently not suppressed by the `contextlib.suppress()` call.

https://github.com/specklesystems/specklepy/blob/420c73f4844d124b1a813b16a2a2ee71a521bccd/src/specklepy/objects/base.py#L312

I agree that this Union type hint with both numeric types and a dictionary is not very common, but it still shouldn't give an error. By also suppressing TypeError, this is prevented.

## Changes:

TypeError is also suppressed. This will suppress the error and of course evaluate to False for a check of a dict value against a float type hint. It will evaluate to True once the dict type hint is reached, i.e. the given dict value passes the check against the total Union type hint.

## Validation of changes:

As said, in my case I had a Union type hint as `Union[float, dict]`. This gave an error when the given value was a dictionary. With this fix, that is prevented and the type check evaluates to True for a dictionary as input.

@gjedlicska 