### PR TITLE
fix(objects)): Fixed issue where breps were incorrectly setting their…

### DIFF
--- a/src/specklepy/objects/geometry.py
+++ b/src/specklepy/objects/geometry.py
@@ -898,7 +898,7 @@ class Brep(
     def VerticesValue(self) -> List[Point]:
         if self.Vertices is None:
             return None
-        encoded_unit = get_encoding_from_units(self.Vertices[0]._units)
+        encoded_unit = get_encoding_from_units(self.Vertices[0].units)
         values = [encoded_unit]
         for vertex in self.Vertices:
             values.extend(vertex.to_list())
@@ -913,7 +913,7 @@ class Brep(
 
         for i in range(0, len(value), 3):
             vertex = Point.from_list(value[i : i + 3])
-            vertex._units = units
+            vertex.units = units
             vertices.append(vertex)
 
         self.Vertices = vertices

--- a/tests/unit/test_geometry.py
+++ b/tests/unit/test_geometry.py
@@ -388,9 +388,9 @@ def test_brep_curve3d_values_serialization(curve, polyline, circle):
 def test_brep_vertices_values_serialization():
     brep = Brep()
     brep.VerticesValue = [1, 1, 1, 1, 2, 2, 2, 3, 3, 3]
-    assert brep.Vertices[0].get_id() == Point(x=1, y=1, z=1, _units=Units.mm).get_id()
-    assert brep.Vertices[1].get_id() == Point(x=2, y=2, z=2, _units=Units.mm).get_id()
-    assert brep.Vertices[2].get_id() == Point(x=3, y=3, z=3, _units=Units.mm).get_id()
+    assert brep.Vertices[0].get_id() == Point(x=1, y=1, z=1, units=Units.mm).get_id()
+    assert brep.Vertices[1].get_id() == Point(x=2, y=2, z=2, units=Units.mm).get_id()
+    assert brep.Vertices[2].get_id() == Point(x=3, y=3, z=3, units=Units.mm).get_id()
 
 
 def test_trims_value_serialization():


### PR DESCRIPTION
Rhino commits with Breps were failing to receive with the recent 2.16.1 changes we made to units.

With a little debugging I tracked this down to a single setter function that was setting the `_units` property directly with a `Units` enum value.
This then was cast directly to str, so became the string `'Units.m'` 
this of course failed when the str -> Units decoding happens later.