### PR TITLE
fix: dict type of renderer in Layer

### DIFF
--- a/src/specklepy/objects/GIS/layers.py
+++ b/src/specklepy/objects/GIS/layers.py
@@ -19,7 +19,7 @@ class Layer(Base, detachable={"features"}):
         features: Optional[List[Base]] = None,
         layerType: str = "None",
         geomType: str = "None",
-        renderer: Optional[dict[str, Any]] = None,
+        renderer: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)


### PR DESCRIPTION
## Description & motivation

Uses the `typing.Dict` intead of `dict` to annotate `renderer` in `objects.GIS.layers.Layer` to be compatible with <3.9.

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
