### PR TITLE
fix: remove fixtures from automate exports

### DIFF
--- a/src/speckle_automate/__init__.py
+++ b/src/speckle_automate/__init__.py
@@ -21,5 +21,4 @@ __all__ = [
     "ObjectResultLevel",
     "run_function",
     "execute_automate_function",
-    "fixtures",
 ]


### PR DESCRIPTION
fixtures are a test dependency, importing them in the main package breaks at runtime, cause we're referencing pytest 