### PR TITLE
fix(automate): remove extra slash

### DIFF
--- a/src/speckle_automate/automation_context.py
+++ b/src/speckle_automate/automation_context.py
@@ -264,7 +264,7 @@ class AutomationContext:
         files = {path_obj.name: open(str(path_obj), "rb")}
 
         url = (
-            f"{self.automation_run_data.speckle_server_url}/api/stream/"
+            f"{self.automation_run_data.speckle_server_url}api/stream/"
             f"{self.automation_run_data.project_id}/blob"
         )
         data = (


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Calls of `automate_context.store_file_result()` would fail for functions with the following error:

```
Client error '404 Not Found' for url 'https://latest.speckle.systems//api/stream/<streamId>/blob'
```

- This is because `automation_run_data.speckle_server_url` was being set with a trailing slash by Automate (e.g. `https://latest.speckle.systems/`) and the sdk appends `/api/stream` to that.

## Changes:

- Changes url construction here (instead of Automate)
