### PR TITLE
fix(automate): add success result case

### DIFF
--- a/src/speckle_automate/automation_context.py
+++ b/src/speckle_automate/automation_context.py
@@ -355,6 +355,24 @@ class AutomationContext:
             visual_overrides,
         )
 
+    def attach_success_to_objects(
+        self,
+        category: str,
+        object_ids: Union[str, List[str]],
+        message: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        visual_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Add a new success case to the run results."""
+        self.attach_result_to_objects(
+            ObjectResultLevel.SUCCESS,
+            category,
+            object_ids,
+            message,
+            metadata,
+            visual_overrides,
+        )
+
     def attach_info_to_objects(
         self,
         category: str,

--- a/src/speckle_automate/schema.py
+++ b/src/speckle_automate/schema.py
@@ -69,6 +69,7 @@ class AutomationStatus(str, Enum):
 class ObjectResultLevel(str, Enum):
     """Possible status message levels for object reports."""
 
+    SUCCESS = "SUCCESS"
     INFO = "INFO"
     WARNING = "WARNING"
     ERROR = "ERROR"


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Object results currently mirror log levels, but are used to report pass/fail information about collections of objects. Some users (@bjoernsteinhagen ) have requested the ability to also surface more information about "success" results with them.
- Frontend will fall back to `INFO` styling, or use new styling ones specklesystems/speckle-server#3537 merged

## Changes:

- Adds `SUCCESS` to enum and util like the others
