### PR TITLE
chore(automate): improve error message when version receive fails

### DIFF
--- a/src/speckle_automate/automation_context.py
+++ b/src/speckle_automate/automation_context.py
@@ -101,8 +101,17 @@ class AutomationContext:
         commit = self.speckle_client.commit.get(
             self.automation_run_data.project_id, version_id
         )
-        if not commit.referencedObject:
-            raise ValueError("The commit has no referencedObject, cannot receive it.")
+        if not commit or not commit.referencedObject:
+            raise ValueError(
+                f"""\
+                             Could not receive specified version.
+                             {"The commit has no referencedObject." if not commit.referencedObject else ""}
+                             Is your environment configured correctly?
+                             project_id: {self.automation_run_data.project_id}
+                             model_id: {self.automation_run_data.triggers[0].payload.model_id}
+                             version_id: {self.automation_run_data.triggers[0].payload.version_id}
+                             """
+            )
         base = operations.receive(
             commit.referencedObject, self._server_transport, self._memory_transport
         )


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We had an issue today where .env values were being cached (?) somewhere. SDK calls to `receive_version()` failed because it was using ids that didn't match the latest configuration.
- This was unclear because the error message was unhelpful
- This is likely to happen when setting up test automations and so we can improve the message

## Changes:

- Adds details about which specific version we attempted to receive when failing
