### PR TITLE
fix for relative path to .env

### DIFF
--- a/src/speckle_automate/fixtures.py
+++ b/src/speckle_automate/fixtures.py
@@ -16,7 +16,7 @@ class TestAutomationEnvironment(BaseSettings):
     """Get known environment variables from local `.env` file"""
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file="../.env",
         env_file_encoding="utf-8",
         env_prefix="speckle_",
         extra="ignore",


### PR DESCRIPTION
I find I have to override this when running tests locally.

Perhaps there is another way, or a failsafe alternative