### PR TITLE
fix (specklepy): removes avatar in version string representation

### DIFF
--- a/src/specklepy/core/api/models/current.py
+++ b/src/specklepy/core/api/models/current.py
@@ -82,6 +82,16 @@ class LimitedUser(GraphQLBaseModel):
     verified: Optional[bool]
     role: Optional[str]
 
+    def __repr__(self):
+        return (
+            f"(name: {self.name}, "
+            f"id: {self.id}, "
+            f"bio: {self.bio}, "
+            f"company: {self.company}, "
+            f"verified: {self.verified}, "
+            f"role: {self.role})"
+        )
+
 
 class PendingStreamCollaborator(GraphQLBaseModel):
     id: str


### PR DESCRIPTION
overrides the LimitedUser repr method to not to have avatar in string representation.

Before:

![image](https://github.com/user-attachments/assets/73f4a23b-d24e-473b-895f-b44e94a44894)

After:

![image](https://github.com/user-attachments/assets/6b5f99fa-ae6b-4e81-b020-eb4863ccddd6)
