### PR TITLE
Publish to testpypi every push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,9 @@
 name: "Publish to PyPI"
 
 on:
-  workflow_run:
-    workflows: [Specklepy test and build]
-    branches: [v3-dev]
-    types:
-      - completed
+  push:
+    branches:
+      - "v3-dev"
 
 jobs:
   pypi-publish:


### PR DESCRIPTION
The changes made in this commit https://github.com/specklesystems/specklepy/commit/adc0c40ab7e7803f1ac20f015d40c72e6373c3cb

don't appear to work, the publish workflow has not triggered since this change was introduced.

To unblock Kate, I will revert this back to run publish on all pushes to v3 dev
We can decide later once @gjedlicska is back what we want to do with this publish workflow