### PR TITLE
feat(api): Updated Version class with schema change to allow null reference object id when version history has been exceeded

### DIFF
--- a/src/specklepy/core/api/models/current.py
+++ b/src/specklepy/core/api/models/current.py
@@ -126,7 +126,8 @@ class ProjectCollaborator(GraphQLBaseModel):
 class Version(GraphQLBaseModel):
     author_user: Optional[LimitedUser]
     created_at: datetime
-    id: str
+    id: Optional[str]
+    """Maybe null if workspaces version history limit has been exceeded"""
     message: Optional[str]
     preview_url: str
     referenced_object: str


### PR DESCRIPTION
The graphql schema was updates in server version 2.23 to return a `null` reference object id on versions when the version history limit has been exceeded.

![image](https://github.com/user-attachments/assets/1cd79003-ec06-453e-8f7a-5f162c28d2a7)
