### PR TITLE
Correct filter serialization

### DIFF
--- a/src/specklepy/core/api/resources/current/active_user_resource.py
+++ b/src/specklepy/core/api/resources/current/active_user_resource.py
@@ -266,7 +266,13 @@ class ActiveUserResource(ResourceBase):
             """  # noqa: E501
         )
 
-        variables = {"limit": limit, "cursor": cursor, "filter": filter}
+        variables = {
+            "limit": limit,
+            "cursor": cursor,
+            "filter": filter.model_dump(warnings="error", by_alias=True)
+            if filter
+            else None,
+        }
 
         response = self.make_request_and_parse_response(
             DataResponse[Optional[DataResponse[ResourceCollection[Workspace]]]],


### PR DESCRIPTION
There was a mistake in https://github.com/specklesystems/specklepy/pull/409
For all gql variables, we need to explicitly serialize strings