### PR TITLE
fic(api): Fix mistake in workspace queries

### DIFF
--- a/src/specklepy/core/api/resources/current/active_user_resource.py
+++ b/src/specklepy/core/api/resources/current/active_user_resource.py
@@ -252,6 +252,10 @@ class ActiveUserResource(ResourceBase):
                     updatedAt
                     readOnly
                     description
+                    creationState
+                    {
+                      completed
+                    }
                     permissions {
                       canCreateProject {
                         authorized

--- a/src/specklepy/core/api/resources/current/active_user_resource.py
+++ b/src/specklepy/core/api/resources/current/active_user_resource.py
@@ -306,6 +306,10 @@ class ActiveUserResource(ResourceBase):
                   updatedAt
                   readOnly
                   description
+                  creationState
+                  {
+                    completed
+                  }
                   permissions {
                     canCreateProject {
                       authorized


### PR DESCRIPTION
One more place I forgot to add the creation state to a workspace query

Because we don't have integration tests for the workspace queries, this slipped through.

@bimgeek this should fix the problem you're seeing in Blender