### PR TITLE
feat: adds `can_load` and `can_publish` permission checks

### DIFF
--- a/src/specklepy/core/api/models/current.py
+++ b/src/specklepy/core/api/models/current.py
@@ -155,6 +155,8 @@ class ModelWithVersions(Model):
 class ProjectPermissionChecks(GraphQLBaseModel):
     can_create_model: "PermissionCheckResult"
     can_delete: "PermissionCheckResult"
+    can_load: "PermissionCheckResult"
+    can_publish: "PermissionCheckResult"
 
 
 class Project(GraphQLBaseModel):

--- a/src/specklepy/core/api/resources/current/project_resource.py
+++ b/src/specklepy/core/api/resources/current/project_resource.py
@@ -73,6 +73,16 @@ class ProjectResource(ResourceBase):
                     code
                     message
                   }
+                  canLoad {
+                    authorized
+                    code
+                    message
+                  }
+                  canPublish {
+                    authorized
+                    code
+                    message
+                  }
                 }
               }
             }


### PR DESCRIPTION
centralized `can_load` and `can_publish` permission checks to not to do same operation in every connector.