### PR TITLE
fix(api)!: `get_active_workspace` now returns a `LimitedWorkspace`

### DIFF
--- a/src/specklepy/api/resources/current/active_user_resource.py
+++ b/src/specklepy/api/resources/current/active_user_resource.py
@@ -12,6 +12,7 @@ from specklepy.core.api.models import (
     User,
 )
 from specklepy.core.api.models.current import (
+    LimitedWorkspace,
     PermissionCheckResult,
     ProjectWithPermissions,
     Workspace,
@@ -94,7 +95,7 @@ class ActiveUserResource(CoreResource):
         metrics.track(metrics.SDK, self.account, {"name": "Active User Get Workspaces"})
         return super().get_workspaces(limit, cursor, filter)
 
-    def get_active_workspace(self) -> Optional[Workspace]:
+    def get_active_workspace(self) -> Optional[LimitedWorkspace]:
         metrics.track(
             metrics.SDK, self.account, {"name": "Active User Get Active Workspace"}
         )

--- a/src/specklepy/core/api/models/current.py
+++ b/src/specklepy/core/api/models/current.py
@@ -213,15 +213,18 @@ class WorkspaceCreationState(GraphQLBaseModel):
     completed: bool
 
 
-class Workspace(GraphQLBaseModel):
+class LimitedWorkspace(GraphQLBaseModel):
     id: str
     name: str
     role: Optional[str]
     slug: str
     logo: Optional[str]
+    description: Optional[str]
+
+
+class Workspace(LimitedWorkspace):
     created_at: datetime
     updated_at: datetime
     read_only: bool
-    description: Optional[str]
     creation_state: Optional[WorkspaceCreationState]
     permissions: WorkspacePermissionChecks

--- a/src/specklepy/core/api/resources/current/active_user_resource.py
+++ b/src/specklepy/core/api/resources/current/active_user_resource.py
@@ -14,6 +14,7 @@ from specklepy.core.api.models import (
     User,
 )
 from specklepy.core.api.models.current import (
+    LimitedWorkspace,
     PermissionCheckResult,
     ProjectWithPermissions,
     Workspace,
@@ -295,7 +296,7 @@ class ActiveUserResource(ResourceBase):
 
         return response.data.data
 
-    def get_active_workspace(self) -> Optional[Workspace]:
+    def get_active_workspace(self) -> Optional[LimitedWorkspace]:
         """
         This feature is only available on Workspace enabled servers  (server versions
         >=2.23.17) e.g. app.speckle.systems
@@ -310,29 +311,15 @@ class ActiveUserResource(ResourceBase):
                   role
                   slug
                   logo
-                  createdAt
-                  updatedAt
-                  readOnly
                   description
-                  creationState
-                  {
-                    completed
-                  }
-                  permissions {
-                    canCreateProject {
-                      authorized
-                      code
-                      message
-                    }
-                  }
                 }
               }
             }
-            """  # noqa: E501
+            """
         )
 
         response = self.make_request_and_parse_response(
-            DataResponse[Optional[DataResponse[Optional[Workspace]]]],
+            DataResponse[Optional[DataResponse[Optional[LimitedWorkspace]]]],
             QUERY,
         )
 


### PR DESCRIPTION
Update the `client.active_user.get_active_workspace` function in response to a breaking change on the server.

<img width="1454" height="646" alt="image" src="https://github.com/user-attachments/assets/53ac79dc-489f-4534-beff-e4348fdf839c" />
