### PR TITLE
fix(speckleifc): Handle edgecase where face count is zero

### DIFF
--- a/src/speckleifc/converter/geometry_converter.py
+++ b/src/speckleifc/converter/geometry_converter.py
@@ -29,7 +29,7 @@ def geometry_to_speckle(
 
     FACE_COUNT = len(material_ids)
 
-    if len(faces) != FACE_COUNT * 3:
+    if len(faces) != FACE_COUNT * 3 or FACE_COUNT == 0:
         # Not really expected, but occasionally some meshes fail to triangulate
         return []
 


### PR DESCRIPTION
Haven't been able to reproduce this case with the current opencascade engine, but while testing the CGAL engine, it was possible for it to output geometry with zero faces, which our code doesn't properly handle.
