### PR TITLE
feat: add building storey info to IFC element properties

### DIFF
--- a/src/speckleifc/converter/data_object_converter.py
+++ b/src/speckleifc/converter/data_object_converter.py
@@ -11,13 +11,20 @@ def data_object_to_speckle(
     display_value: list[Base],
     step_element: entity_instance,
     children: list[Base],
+    current_storey: str | None = None,
 ) -> DataObject:
     guid = cast(str, step_element.GlobalId)
     name = cast(str, step_element.Name or guid)
 
+    properties = extract_properties(step_element)
+
+    # Add building storey information if available and not a building storey itself
+    if current_storey and not step_element.is_a("IfcBuildingStorey"):
+        properties["Building Storey"] = current_storey
+
     data_object = DataObject(
         applicationId=guid,
-        properties=extract_properties(step_element),
+        properties=properties,
         name=name or guid,
         displayValue=display_value,
     )

--- a/src/speckleifc/converter/spatial_element_converter.py
+++ b/src/speckleifc/converter/spatial_element_converter.py
@@ -12,8 +12,11 @@ def spatial_element_to_speckle(
     display_value: list[Base],
     step_element: entity_instance,
     relational_children: list[Base],
+    current_storey: str | None = None,
 ) -> Collection:
-    direct_geometry = _convert_as_data_object(display_value, step_element)
+    direct_geometry = _convert_as_data_object(
+        display_value, step_element, current_storey
+    )
     all_children = [direct_geometry] + relational_children
 
     guid = cast(str, step_element.GlobalId)
@@ -26,13 +29,22 @@ def spatial_element_to_speckle(
 
 
 def _convert_as_data_object(
-    display_value: list[Base], step_element: entity_instance
+    display_value: list[Base],
+    step_element: entity_instance,
+    current_storey: str | None = None,
 ) -> DataObject:
     guid = cast(str, step_element.GlobalId)
     name = cast(str, step_element.Name or step_element.LongName or guid)
+
+    properties = extract_properties(step_element)
+
+    # Add building storey information if available and not a building storey itself
+    if current_storey and not step_element.is_a("IfcBuildingStorey"):
+        properties["Building Storey"] = current_storey
+
     data_object = DataObject(
         applicationId=guid,
-        properties=extract_properties(step_element),
+        properties=properties,
         name=name,
         displayValue=display_value,
     )

--- a/src/speckleifc/property_extraction.py
+++ b/src/speckleifc/property_extraction.py
@@ -10,10 +10,6 @@ def extract_properties(element: entity_instance) -> dict[str, object]:
         "Property Sets": _get_ifc_object_properties(element),
     }
 
-    # Add building storey information if element is contained in a storey
-    if storey_name := _get_containing_storey(element):
-        properties["Building Storey"] = storey_name
-
     if (ifc_type := get_type(element)) is not None:
         properties["Element Type Property Sets"] = _get_ifc_element_type_properties(
             ifc_type,
@@ -94,38 +90,3 @@ def _get_properties(properties: entity_instance) -> dict[str, Any]:
         # elif prop.is_a("IfcPropertyTableValue"):
         #     properties[name] = #not sure if we want to support these...
     return result
-
-
-def _get_containing_storey(element: entity_instance) -> str | None:
-    """
-    Find the containing IfcBuildingStorey for an element by traversing up
-    the spatial hierarchy. Returns the storey name if found, None otherwise.
-    """
-    # Check if element has spatial containment relationships
-    containment_rels = getattr(element, "ContainedInStructure", None)
-    if not containment_rels:
-        return None
-
-    # Traverse the spatial containment relationships
-    for rel in containment_rels:
-        if not rel.is_a("IfcRelContainedInSpatialStructure"):
-            continue
-
-        relating_structure = getattr(rel, "RelatingStructure", None)
-        if not relating_structure:
-            continue
-
-        # Check if this structure is a building storey
-        if relating_structure.is_a("IfcBuildingStorey"):
-            return (
-                relating_structure.Name
-                or relating_structure.LongName
-                or relating_structure.GlobalId
-            )
-
-        # If not, recursively check the parent structure
-        parent_storey = _get_containing_storey(relating_structure)
-        if parent_storey:
-            return parent_storey
-
-    return None


### PR DESCRIPTION
## Description & motivation

This PR adds building storey information to individual IFC elements during property extraction. When users select an element in Speckle, they can now see which building storey contains that element directly in the properties panel.

Relates to issue CNX-2393.

## Changes:

- Added context tracking to `ImportJob` class to maintain current building storey during tree traversal
- Modified converters to accept and inject storey information during DataObject creation

## Screenshots:

<img width="1920" height="1080" alt="zen_WMJzfenuI2" src="https://github.com/user-attachments/assets/8c452e70-82b0-466e-8950-b141504bf777" />

## Validation of changes:

- Tested with various IFC files containing multi-storey buildings
- Verified elements without storey containment don't break (returns None gracefully)
- Confirmed nested spatial structures are handled correctly

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
