### PR TITLE
feat(speckleifc): Add Metrics tracking

### DIFF
--- a/src/speckleifc/__main__.py
+++ b/src/speckleifc/__main__.py
@@ -6,6 +6,7 @@ from os import getenv
 
 from speckleifc.main import open_and_convert_file
 from specklepy.core.api.client import SpeckleClient
+from specklepy.logging import metrics
 
 
 def cmd_line_import() -> None:
@@ -27,12 +28,18 @@ def cmd_line_import() -> None:
     assert TOKEN is not None
     SERVER_URL = getenv("SPECKLE_SERVER_URL") or "http://127.0.0.1:3000"
 
+    metrics.set_host_app(
+        "ifc",
+    )
+
     try:
         client = SpeckleClient(SERVER_URL, use_ssl=not SERVER_URL.startswith("http://"))
         client.authenticate_with_token(TOKEN)
+        project = client.project.get(args.project_id)
+
         version = open_and_convert_file(
             args.file_path,
-            args.project_id,
+            project,
             args.version_message,
             args.model_id,
             client,

--- a/src/speckleifc/importer.py
+++ b/src/speckleifc/importer.py
@@ -100,5 +100,6 @@ class ImportJob:
         tree["renderMaterialProxies"] = list(
             self._render_material_manager.render_material_proxies.values()
         )
+        tree["version"] = 3
 
         return tree

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -4,18 +4,18 @@ from speckleifc.ifc_geometry_processing import open_ifc
 from speckleifc.importer import ImportJob
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.inputs.version_inputs import CreateVersionInput
-from specklepy.core.api.models.current import Version
+from specklepy.core.api.models.current import Project, Version
 from specklepy.core.api.operations import send
+from specklepy.logging import metrics
 from specklepy.transports.server import ServerTransport
 
 
 def open_and_convert_file(
     file_path: str,
-    project_id: str,
+    project: Project,
     version_message: str | None,
     model_id: str,
     client: SpeckleClient,
-    # account: Account,
 ) -> Version:
     start = time.time()
     very_start = start
@@ -23,7 +23,7 @@ def open_and_convert_file(
     account = client.account
     server_url = account.serverInfo.url
     assert server_url
-    remote_transport = ServerTransport(project_id, account=account)
+    remote_transport = ServerTransport(project.id, account=account)
 
     ifc_file = open_ifc(file_path)  # pyright: ignore[reportUnknownVariableType]
     import_job = ImportJob(ifc_file)  # pyright: ignore[reportUnknownArgumentType]
@@ -41,9 +41,9 @@ def open_and_convert_file(
     create_version = CreateVersionInput(
         object_id=root_id,
         model_id=model_id,
-        project_id=project_id,
+        project_id=project.id,
         message=version_message,
-        source_application="IFC",
+        source_application="ifc",
     )
     version = client.version.create(create_version)
     end = time.time()
@@ -51,5 +51,10 @@ def open_and_convert_file(
 
     print(f"Total time (to commit): {(end - very_start) * 1000}ms")
     del ifc_file
+
+    custom_properties = {"ui": "dui3", "actionSource": "import"}
+    if project.workspace_id:
+        custom_properties["workspace_id"] = project.workspace_id
+    metrics.track(metrics.SEND, account, custom_properties)
 
     return version


### PR DESCRIPTION
Implemented the changes we discussed @gjedlicska @clairekuang for the IFC importer


This PR adds Mixpanel Send event tracking to the IFC Importer
It also changes the slug reported to the `VersionCreate` from `"IFC"` to `"ifc"` to align with the ifc slug.

Note... I'm not doing any `ifc-ifcopenshell-importer` slugs, as this would be a breaking change as far as historical IFC metrics is concerned, and also doesn't really offer value so long as our IFC importer only converts ifc files...

<img width="3267" height="705" alt="image" src="https://github.com/user-attachments/assets/2854f4f4-5862-49c1-a8d0-915d015dbd41" />

see https://github.com/specklesystems/speckle-sharp-connectors/pull/1063