### PR TITLE
Fix log warnings caused by mistake in args

### DIFF
--- a/src/specklepy/transports/server/batch_sender.py
+++ b/src/specklepy/transports/server/batch_sender.py
@@ -123,8 +123,8 @@ class BatchSender:
         upload_data = "[" + ",".join(new_objects) + "]"
         upload_data_gzip = gzip.compress(upload_data.encode())
         LOG.info(
-            "Uploading batch of {batch_size} objects {new_object_count}: ",
-            "(size: {upload_size}, compressed size: {upload_data_size})",
+            "Uploading batch of {batch_size} objects {new_object_count}: "
+            + "(size: {upload_size}, compressed size: {upload_data_size})",
             {
                 "batch_size": len(batch),
                 "new_object_count": len(new_objects),


### PR DESCRIPTION
There was a mistake in one of our calls to the logger that was generating lots of warnings when running the ifc import service

```
  File "/app/lib/python3.13/site-packages/specklepy/transports/server/batch_sender.py", line 125, in _bg_send_batch

    LOG.info(

Message: 'Uploading batch of {batch_size} objects {new_object_count}: '

Arguments: ('(size: {upload_size}, compressed size: {upload_data_size})', {'batch_size': 2, 'new_object_count': 2, 'upload_size': 944518, 'upload_data_size': 67254})
```