### PR TITLE
fic(ifc): Fix for element quantities that contain nan values 

### DIFF
--- a/src/speckleifc/property_extraction.py
+++ b/src/speckleifc/property_extraction.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Tuple
 
 from ifcopenshell.entity_instance import entity_instance
@@ -133,6 +134,10 @@ def _get_quantities(
             # Get the quantity value (3rd attribute for simple quantities)
             value = getattr(quantity, quantity.attribute_name(3))
             unit_info = _get_unit_info(element, quantity)
+
+            # Server does not consider `NaN` valid json
+            if math.isnan(value):
+                value = None
 
             if unit_info:
                 # Create structured quantity object with units


### PR DESCRIPTION
We got some alerts of a flood of 400 errors triggered by IFC uploads.

I believe this is caused by `NaN` values being sent to the server.
js and python disagree with how to serialize NaN values, so the server was handling the post requests to `/objects/:streamId` as invalid json.

In this PR, for IFC values that we know may be NaN,  I'm mapping them to `None` values.
This follows the js standard of mapping to `null` value
The python standard is to serialize them as a `NaN` keyword value.

I've also see other serializers write a `"NaN"` value instead... but felt that `none` is easier to deal with than mixing types.