### PR TITLE
feat: register all object types on package import

### DIFF
--- a/src/specklepy/objects/__init__.py
+++ b/src/specklepy/objects/__init__.py
@@ -1,3 +1,66 @@
-from .data_objects import Base, DataObject, QgisObject, BlenderObject  # noqa: I001
+from .annotation import Text
+from .data_objects import Base, BlenderObject, DataObject, QgisObject
+from .geometry import (
+    Arc,
+    Box,
+    Circle,
+    ControlPoint,
+    Curve,
+    Ellipse,
+    Line,
+    Mesh,
+    Plane,
+    Point,
+    PointCloud,
+    Polycurve,
+    Polyline,
+    Region,
+    Spiral,
+    Surface,
+    Vector,
+)
+from .models.collections import Collection
+from .other import RenderMaterial
+from .primitive import Interval
+from .proxies import (
+    ColorProxy,
+    GroupProxy,
+    InstanceDefinitionProxy,
+    InstanceProxy,
+    LevelProxy,
+    RenderMaterialProxy,
+)
 
-__all__ = ["Base", "DataObject", "QgisObject", "BlenderObject"]
+__all__ = [
+    "Arc",
+    "Base",
+    "BlenderObject",
+    "Box",
+    "Circle",
+    "ColorProxy",
+    "Collection",
+    "ControlPoint",
+    "Curve",
+    "DataObject",
+    "Ellipse",
+    "GroupProxy",
+    "InstanceDefinitionProxy",
+    "InstanceProxy",
+    "Interval",
+    "LevelProxy",
+    "Line",
+    "Mesh",
+    "Plane",
+    "Point",
+    "PointCloud",
+    "Polycurve",
+    "Polyline",
+    "QgisObject",
+    "Region",
+    "RenderMaterial",
+    "RenderMaterialProxy",
+    "Spiral",
+    "Surface",
+    "Text",
+    "Vector",
+]

--- a/src/specklepy/objects/models/__init__.py
+++ b/src/specklepy/objects/models/__init__.py
@@ -1,0 +1,3 @@
+from .collections import Collection
+
+__all__ = ["Collection"]

--- a/src/specklepy/objects/models/collections/__init__.py
+++ b/src/specklepy/objects/models/collections/__init__.py
@@ -1,0 +1,3 @@
+from .collection import Collection
+
+__all__ = ["Collection"]


### PR DESCRIPTION
If user doesn't explicitly import a type (e.g. Collection), the class never loads, so it's missing from `_type_registry`. The deserializer then silently falls back to Base.

Fix -> eager-load every object type in `specklepy/objects/__init__.py` so importing specklepy alone populates the registry. 