### PR TITLE
fix(api): Respect Retry After Header

### DIFF
--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -5,20 +5,17 @@ services:
   # Speckle Server dependencies
   #######
   postgres:
-    image: "postgres:16.4-alpine3.20@sha256:d898b0b78a2627cb4ee63464a14efc9d296884f1b28c841b0ab7d7c42f1fffdf"
+    image: 'postgres:18.3-alpine3.23@sha256:54451ecb8ab38c24c3ec123f2fd501303a3a1856a5c66e98cecf2460d5e1e9d7'
     restart: always
     environment:
       POSTGRES_DB: speckle
       POSTGRES_USER: speckle
       POSTGRES_PASSWORD: speckle
     volumes:
-      - ./.volumes/postgres-data:/var/lib/postgresql/data/
-    healthcheck:
-      # the -U user has to match the POSTGRES_USER value
-      test: ["CMD-SHELL", "pg_isready -U speckle"]
-      interval: 5s
-      timeout: 5s
-      retries: 30
+      - ./.volumes/postgres-data:/var/lib/postgresql
+      - ./setup/db/10-docker_postgres_init.sql:/docker-entrypoint-initdb.d/10-docker_postgres_init.sql
+      - ./setup/db/11-docker_postgres_authentik_init.sql:/docker-entrypoint-initdb.d/11-docker_postgres_authentik_init.sql
+    command: postgres -c max_prepared_transactions=150
 
   redis:
     image: "valkey/valkey:8.1-alpine@sha256:0d27f0bca0249f61d060029a6aaf2e16b2c417d68d02a508e1dfb763fa2948b4"
@@ -32,7 +29,7 @@ services:
       retries: 30
 
   minio:
-    image: "minio/minio:RELEASE.2023-10-25T06-33-25Z"
+    image: "minio/minio:RELEASE.2025-09-07T16-13-09Z"
     command: server /data --console-address ":9001"
     restart: always
     volumes:
@@ -101,9 +98,6 @@ services:
       ENABLE_MP: "false"
 
       LOG_PRETTY: "true"
-
-      FF_NEXT_GEN_FILE_IMPORTER_ENABLED: "true"
-      FF_LARGE_FILE_IMPORTS_ENABLED: "true"
 
 networks:
   default:

--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -16,6 +16,12 @@ services:
       - ./setup/db/10-docker_postgres_init.sql:/docker-entrypoint-initdb.d/10-docker_postgres_init.sql
       - ./setup/db/11-docker_postgres_authentik_init.sql:/docker-entrypoint-initdb.d/11-docker_postgres_authentik_init.sql
     command: postgres -c max_prepared_transactions=150
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U speckle -d speckle"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   redis:
     image: "valkey/valkey:8.1-alpine@sha256:0d27f0bca0249f61d060029a6aaf2e16b2c417d68d02a508e1dfb763fa2948b4"
@@ -65,17 +71,16 @@ services:
       - "0.0.0.0:3000:3000"
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_healthy
       minio:
         condition: service_healthy
     environment:
-      # TODO: Change this to the URL of the speckle server, as accessed from the network
-      CANONICAL_URL: "http://127.0.0.1:8080"
+      CANONICAL_URL: "http://127.0.0.1:3000"
       SPECKLE_AUTOMATE_URL: "http://127.0.0.1:3030"
       FRONTEND_ORIGIN: "http://127.0.0.1:8081"
-
+      BIND_ADDRESS: "0.0.0.0"
       # TODO: Change thvolumes:
       REDIS_URL: "redis://redis"
 

--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -65,7 +65,7 @@ services:
       - "0.0.0.0:3000:3000"
     depends_on:
       postgres:
-        condition: service_healthy
+        condition: service_started
       redis:
         condition: service_healthy
       minio:

--- a/src/specklepy/transports/server/retry_policy.py
+++ b/src/specklepy/transports/server/retry_policy.py
@@ -24,6 +24,7 @@ def setup_session(auth_token: str | None) -> requests.Session:
         status_forcelist=(500, 502, 503, 504, 520, 408, 429),
         allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"],
         raise_on_status=False,
+        respect_retry_after_header=True,
     )
 
     adapter = HTTPAdapter(max_retries=retry_policy)


### PR DESCRIPTION
We see some IFC ingestions failing because they're hitting rate limiting when uploading batches of objects to the server...

for some reason, the current backoff retry is either not working for 429, or is not sufficient for our retrying.

This pr enables a option on the `Retry` policy to respect the retry after header. Hopefully this should prevent failed ingestions.
If this doesn't resolve the issue, we'll need to investigate further as to why the retrying is not working properly.