### PR TITLE
feat(speckleifc): extract MEP network topology (systems + port connectivity)

### DIFF
--- a/src/speckleifc/importer.py
+++ b/src/speckleifc/importer.py
@@ -12,11 +12,13 @@ from speckleifc.converter.project_converter import project_to_speckle
 from speckleifc.converter.spatial_element_converter import spatial_element_to_speckle
 from speckleifc.ifc_geometry_processing import create_geometry_iterator
 from speckleifc.ifc_openshell_helpers import get_children
+from speckleifc.proxy_managers.connection_proxy_manager import ConnectionProxyManager
 from speckleifc.proxy_managers.instance_proxy_manager import InstanceProxyManager
 from speckleifc.proxy_managers.level_proxy_manager import LevelProxyManager
 from speckleifc.proxy_managers.render_material_proxy_manager import (
     RenderMaterialProxyManager,
 )
+from speckleifc.proxy_managers.system_proxy_manager import SystemProxyManager
 from specklepy.logging.exceptions import SpeckleException
 from specklepy.objects import Base
 from specklepy.objects.data_objects import DataObject
@@ -39,6 +41,12 @@ class ImportJob:
     )
     _instance_proxy_manager: InstanceProxyManager = field(
         default_factory=lambda: InstanceProxyManager()
+    )
+    _system_proxy_manager: SystemProxyManager = field(
+        default_factory=lambda: SystemProxyManager()
+    )
+    _connection_proxy_manager: ConnectionProxyManager = field(
+        default_factory=lambda: ConnectionProxyManager()
     )
     geometries_count: int = 0
     geometries_used: int = 0
@@ -232,6 +240,16 @@ class ImportJob:
         tree["instanceDefinitionProxies"] = list(
             self._instance_proxy_manager.instance_definition_proxies.values()
         )
+
+        # Network topology: system membership + port-connectivity edges.
+        # Extracted directly from the IFC graph (global relationships, not
+        # per-element), so run once over the whole file here.
+        self._system_proxy_manager.extract(self.ifc_file)
+        self._connection_proxy_manager.extract(self.ifc_file)
+        tree["systemProxies"] = list(
+            self._system_proxy_manager.system_proxies.values()
+        )
+        tree["connectionProxies"] = self._connection_proxy_manager.connection_proxies
         tree.elements.append(
             Collection(
                 name="definitionGeometry",

--- a/src/speckleifc/proxy_managers/connection_proxy_manager.py
+++ b/src/speckleifc/proxy_managers/connection_proxy_manager.py
@@ -1,0 +1,63 @@
+from ifcopenshell import file
+from ifcopenshell.entity_instance import entity_instance
+
+from specklepy.objects.proxies import ConnectionProxy
+
+
+class ConnectionProxyManager:
+    """
+    Builds ConnectionProxies from IFC port connectivity.
+
+    Distribution elements (pipes, fittings, terminals) carry
+    ``IfcDistributionPort`` nodes, and ``IfcRelConnectsPorts`` links a pair of
+    ports. Resolving each port back to its owning element (via the nesting
+    relationship, or the legacy port-to-element relationship) yields the
+    element-level network graph: one ConnectionProxy per edge.
+    """
+
+    def __init__(self):
+        self._connection_proxies: list[ConnectionProxy] = []
+
+    @property
+    def connection_proxies(self) -> list[ConnectionProxy]:
+        return self._connection_proxies
+
+    @staticmethod
+    def _owner_of_port(port: entity_instance | None) -> entity_instance | None:
+        if port is None:
+            return None
+        # IFC4: port nested under its element via IfcRelNests (inverse: Nests)
+        for rel in getattr(port, "Nests", None) or []:
+            if rel.RelatingObject is not None:
+                return rel.RelatingObject
+        # Legacy: IfcRelConnectsPortToElement (inverse: ContainedIn)
+        for rel in getattr(port, "ContainedIn", None) or []:
+            if getattr(rel, "RelatedElement", None) is not None:
+                return rel.RelatedElement
+        return None
+
+    def extract(self, ifc_file: file) -> None:
+        for rel in ifc_file.by_type("IfcRelConnectsPorts"):
+            source = self._owner_of_port(rel.RelatingPort)
+            target = self._owner_of_port(rel.RelatedPort)
+            if source is None or target is None:
+                continue
+
+            source_id = getattr(source, "GlobalId", None)
+            target_id = getattr(target, "GlobalId", None)
+            if not source_id or not target_id:
+                continue
+
+            self._connection_proxies.append(
+                ConnectionProxy(
+                    sourceAppId=source_id,
+                    targetAppId=target_id,
+                    applicationId=getattr(rel, "GlobalId", None),
+                    sourceFlowDirection=getattr(
+                        rel.RelatingPort, "FlowDirection", None
+                    ),
+                    targetFlowDirection=getattr(
+                        rel.RelatedPort, "FlowDirection", None
+                    ),
+                )
+            )

--- a/src/speckleifc/proxy_managers/system_proxy_manager.py
+++ b/src/speckleifc/proxy_managers/system_proxy_manager.py
@@ -1,0 +1,58 @@
+from ifcopenshell import file
+from ifcopenshell.entity_instance import entity_instance
+
+from specklepy.objects.proxies import SystemProxy
+
+
+class SystemProxyManager:
+    """
+    Builds SystemProxies from IFC system grouping.
+
+    IFC groups distribution-network elements into ``IfcSystem`` /
+    ``IfcDistributionSystem`` via ``IfcRelAssignsToGroup``. Each such group
+    becomes one SystemProxy listing its member application ids, so the EAV
+    ingestion can denormalise system membership onto each element.
+    """
+
+    def __init__(self):
+        self._system_proxies: dict[str, SystemProxy] = {}
+
+    @property
+    def system_proxies(self) -> dict[str, SystemProxy]:
+        return self._system_proxies
+
+    def extract(self, ifc_file: file) -> None:
+        for rel in ifc_file.by_type("IfcRelAssignsToGroup"):
+            group: entity_instance | None = rel.RelatingGroup
+            if group is None:
+                continue
+            if not (group.is_a("IfcSystem") or group.is_a("IfcDistributionSystem")):
+                continue
+
+            group_id = getattr(group, "GlobalId", None)
+            if not group_id:
+                continue
+
+            members = [
+                o.GlobalId
+                for o in (rel.RelatedObjects or [])
+                if getattr(o, "GlobalId", None)
+            ]
+            if not members:
+                continue
+
+            existing = self._system_proxies.get(group_id)
+            if existing is not None:
+                # Same system can be assigned in multiple relationships
+                existing.objects.extend(members)
+                continue
+
+            system_type = getattr(group, "PredefinedType", None) or getattr(
+                group, "ObjectType", None
+            )
+            self._system_proxies[group_id] = SystemProxy(
+                objects=members,
+                name=group.Name or group_id,
+                applicationId=group_id,
+                systemType=system_type,
+            )

--- a/src/specklepy/objects/proxies.py
+++ b/src/specklepy/objects/proxies.py
@@ -28,6 +28,64 @@ class GroupProxy(
 
 
 @dataclass(kw_only=True)
+class SystemProxy(
+    Base,
+    speckle_type="Speckle.Core.Models.Proxies.SystemProxy",
+    detachable={"objects"},
+):
+    """
+    Stores logical system (e.g. MEP distribution system) membership in root
+    collections. Sourced from IFC ``IfcSystem`` / ``IfcDistributionSystem``
+    grouping (``IfcRelAssignsToGroup``).
+
+    Args:
+        objects (list): application ids of the member elements
+        name (str): the system name (e.g. "S_Schmutzwasser")
+        applicationId (str): the IfcSystem GlobalId
+        systemType (str | None): predefined/object type, when present
+    """
+
+    objects: List[str]
+    name: str
+    applicationId: Optional[str]
+    systemType: Optional[str] = None
+
+
+@dataclass(kw_only=True)
+class ConnectionProxy(
+    Base,
+    speckle_type="Speckle.Core.Models.Proxies.ConnectionProxy",
+):
+    """
+    Stores a single network-connectivity edge between two elements, sourced
+    from IFC port connectivity (``IfcRelConnectsPorts`` resolved through the
+    ports' owning elements via ``IfcRelNests`` / ``IfcRelConnectsPortToElement``).
+
+    An edge is a directed pair with distinct endpoint roles, so the endpoints
+    are named fields rather than a positional ``objects`` list.
+
+    Args:
+        sourceAppId (str): application id of the source-end element
+            (owner of the relating port)
+        targetAppId (str): application id of the target-end element
+            (owner of the related port)
+        applicationId (str): the IfcRelConnectsPorts GlobalId
+        sourceFlowDirection (str | None): the source-end (relating) port's
+            FlowDirection (SOURCE / SINK / SOURCEANDSINK / NOTDEFINED)
+        targetFlowDirection (str | None): the target-end (related) port's
+            FlowDirection. Capturing both ends lets a consumer orient the edge
+            (SOURCE→SINK) where the data defines it; gravity systems remain
+            SOURCEANDSINK on both ends and stay undirected.
+    """
+
+    sourceAppId: str
+    targetAppId: str
+    applicationId: Optional[str]
+    sourceFlowDirection: Optional[str] = None
+    targetFlowDirection: Optional[str] = None
+
+
+@dataclass(kw_only=True)
 class InstanceProxy(
     Base,
     IHasUnits,


### PR DESCRIPTION
## What

Teaches the IFC converter to extract **MEP / distribution-network topology**, which it previously discarded. Two new proxy managers, attached to the root collection alongside the existing level / material / instance proxies:

- **`SystemProxyManager`** — `IfcSystem` / `IfcDistributionSystem` grouping (`IfcRelAssignsToGroup`) → `SystemProxy` (`systemProxies`), one per system listing its member application ids.
- **`ConnectionProxyManager`** — `IfcRelConnectsPorts` resolved through each port's owning element (`IfcRelNests`, with `IfcRelConnectsPortToElement` fallback) → one `ConnectionProxy` per edge (`connectionProxies`). Captures **both** ports' `FlowDirection` (`sourceFlowDirection` / `targetFlowDirection`) so a consumer can orient the graph `SOURCE → SINK` where the data defines it; gravity `SOURCEANDSINK` edges stay undirected.

New `SystemProxy` / `ConnectionProxy` `Base` types in `objects/proxies.py`.

## Why

Downstream this lets us denormalise system membership + a connection graph into the EAV layer and drive a `trace_network` agent tool (trace a fixture to its drain/source, "what's on this circuit", etc.). The converter is the only place this relationship data is available, so it has to originate here.

## Testing

⚠️ Tested **briefly, and only** with the Version 2 sample files from https://github.com/RWTH-E3D/DigitalHub/tree/master/Version_2 (sanitary, heating, and ventilation models). Against those:
- system membership extracted correctly (e.g. `S_Schmutzwasser`, `H_Transport_RL_*`, `V_Zuluft`/`V_Abluft`)
- 100% of `IfcRelConnectsPorts` resolved to element-level edges
- flow orientation: ~74% of edges oriented on the mixed gravity sanitary model, ~98% on the pressurised heating/ventilation ones

Not yet exercised against other exporters / schemas, so a second pair of eyes on the port-resolution + flow-direction handling would be welcome.

@JR-Morgan tagging you for review.