### PR TITLE
Feature: artefact bundle producer + IFC converter (opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ venv.bak/
 # other
 scratch.py
 settings.json
+
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ version = "2.9.2"
 tag_format = "$version"
 
 [tool.ruff]
-exclude = [".venv", "**/*.yml"]
+# bundle/spec is generated + vendored from speckle-bundle-spec — don't lint generated code.
+exclude = [".venv", "**/*.yml", "src/specklepy/bundle/spec"]
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-speckleifc = ["ifcopenshell>=0.8.5"]
+# Speckle 4.0 bundle producer (eav + envelope + geometries parquet). pyarrow writes the
+# parquet tables; duckdb is used to read/validate them in tests and by consumers.
+bundle = ["pyarrow>=17.0.0", "duckdb>=1.1.0"]
+speckleifc = ["ifcopenshell>=0.8.5", "specklepy[bundle]"]
 
 [dependency-groups]
 

--- a/src/speckleifc/bundle_exporter.py
+++ b/src/speckleifc/bundle_exporter.py
@@ -4,12 +4,12 @@ The IFC ``ImportJob.convert()`` returns a root ``Collection`` whose scene tree
 (collections + DataObjects + InstanceProxy displayValues) and attached proxy lists
 (instanceDefinitionProxies / renderMaterialProxies / levelProxies / systemProxies /
 connectionProxies) map directly onto the envelope graph. This module performs that
-mapping via :class:`~specklepy.bundle.pipeline.ObjectsArtifactPipeline` — no re-reading of
-the IFC file; everything comes from the already-converted ``Base`` tree.
+mapping via :class:`~specklepy.bundle.pipeline.ObjectsArtifactPipeline` — no
+re-reading of the IFC file; everything comes from the already-converted ``Base`` tree.
 
-Emission order matters: definitions (+ their geometries) and materials first, so the scene
-walk's instances and the material edges can reference the geometry/definition Ks already
-minted.
+Emission order matters: definitions (+ their geometries) and materials first, so the
+scene walk's instances and the material edges can reference the geometry/definition
+Ks already minted.
 """
 
 from __future__ import annotations
@@ -45,7 +45,10 @@ class IfcBundleExporter:
         self._has_levels = False
 
     def export(self, root: Collection) -> tuple[str, int]:
-        """Emit the whole bundle. Returns ``(root_id, object_count)`` for the uploader."""
+        """Emit the whole bundle.
+
+        Returns ``(root_id, object_count)`` for the uploader.
+        """
         mesh_by_id = self._index_definition_geometry(root)
 
         self._emit_definitions(root, mesh_by_id)
@@ -65,7 +68,8 @@ class IfcBundleExporter:
     # ── geometry / definitions ──────────────────────────────────────────────
 
     def _index_definition_geometry(self, root: Collection) -> dict[str, Mesh]:
-        """Build {mesh.applicationId -> Mesh} from the appended ``definitionGeometry`` collection."""
+        """Build {mesh.applicationId -> Mesh} from the appended
+        ``definitionGeometry`` collection."""
         index: dict[str, Mesh] = {}
         for el in _attr(root, "elements", []) or []:
             if isinstance(el, Collection) and _attr(el, "name") == _DEFINITION_GEOMETRY:
@@ -144,7 +148,8 @@ class IfcBundleExporter:
                 ],
             )
 
-            # membership: under a Collection -> IN_COLLECTION; under a DataObject -> SUBELEMENT.
+            # membership: under a Collection -> IN_COLLECTION; under a DataObject ->
+            # SUBELEMENT.
             if parent_object_k is not None:
                 self._pipeline.subelement(parent_object_k, obj_k, ord)
             elif parent_collection_k is not None:
@@ -211,10 +216,15 @@ class IfcBundleExporter:
                 continue
             name = _attr(proxy, "name")
             system_type = _attr(proxy, "systemType")
-            # Canonical container subtype stays "System" (cross-connector); the IFC system type
-            # (PredefinedType/ObjectType) rides on the display name so it isn't lost — but only when
-            # it adds information (some exports set ObjectType == Name, e.g. "S_PWC").
-            display = f"{name} ({system_type})" if system_type and system_type != name else name
+            # Canonical container subtype stays "System" (cross-connector); the IFC
+            # system type (PredefinedType/ObjectType) rides on the display name so it
+            # isn't lost — but only when it adds information (some exports set
+            # ObjectType == Name, e.g. "S_PWC").
+            display = (
+                f"{name} ({system_type})"
+                if system_type and system_type != name
+                else name
+            )
             sys_k = self._pipeline.add_container(system_id, display, None, "System")
             for member_id in _attr(proxy, "objects", []) or []:
                 obj_k = self._pipeline.intern_object(member_id)
@@ -231,8 +241,9 @@ class IfcBundleExporter:
             src_flow = _attr(proxy, "sourceFlowDirection")
             tgt_flow = _attr(proxy, "targetFlowDirection")
 
-            # Orient by FlowDirection: SOURCE->SINK is a directed edge (flip if reversed);
-            # anything else (SOURCEANDSINK / NOTDEFINED / missing) is undirected -> reciprocal pair.
+            # Orient by FlowDirection: SOURCE->SINK is a directed edge (flip if
+            # reversed); anything else (SOURCEANDSINK / NOTDEFINED / missing) is
+            # undirected -> reciprocal pair.
             if src_flow == "SOURCE" and tgt_flow == "SINK":
                 self._pipeline.connects_to(src_k, tgt_k)
             elif src_flow == "SINK" and tgt_flow == "SOURCE":

--- a/src/speckleifc/bundle_exporter.py
+++ b/src/speckleifc/bundle_exporter.py
@@ -211,9 +211,10 @@ class IfcBundleExporter:
                 continue
             name = _attr(proxy, "name")
             system_type = _attr(proxy, "systemType")
-            # Canonical container subtype stays "System" (cross-connector); the IFC PredefinedType
-            # rides on the display name so it isn't lost.
-            display = f"{name} ({system_type})" if system_type else name
+            # Canonical container subtype stays "System" (cross-connector); the IFC system type
+            # (PredefinedType/ObjectType) rides on the display name so it isn't lost — but only when
+            # it adds information (some exports set ObjectType == Name, e.g. "S_PWC").
+            display = f"{name} ({system_type})" if system_type and system_type != name else name
             sys_k = self._pipeline.add_container(system_id, display, None, "System")
             for member_id in _attr(proxy, "objects", []) or []:
                 obj_k = self._pipeline.intern_object(member_id)

--- a/src/speckleifc/bundle_exporter.py
+++ b/src/speckleifc/bundle_exporter.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from specklepy.bundle.envelope_writer import SceneView, SceneViewKey
 from specklepy.bundle.pipeline import ObjectsArtifactPipeline
+from specklepy.bundle.spec import Rel
 from specklepy.objects.base import Base
 from specklepy.objects.data_objects import DataObject
 from specklepy.objects.geometry import Mesh
@@ -40,6 +42,7 @@ class IfcBundleExporter:
         self._pipeline = ObjectsArtifactPipeline(output_dir, base_name)
         self._def_k_by_id: dict[str, int] = {}
         self._object_count = 0
+        self._has_levels = False
 
     def export(self, root: Collection) -> tuple[str, int]:
         """Emit the whole bundle. Returns ``(root_id, object_count)`` for the uploader."""
@@ -53,6 +56,7 @@ class IfcBundleExporter:
         self._emit_levels(root)
         self._emit_systems(root)
         self._emit_connections(root)
+        self._emit_default_scene_view()
 
         self._pipeline.complete()
         root_id = _attr(root, "applicationId") or "root"
@@ -182,6 +186,23 @@ class IfcBundleExporter:
             for member_id in _attr(proxy, "objects", []) or []:
                 obj_k = self._pipeline.intern_object(member_id)
                 self._pipeline.on_level(obj_k, lvl_k)
+                self._has_levels = True
+
+    def _emit_default_scene_view(self) -> None:
+        """Author the producer's default scene-explorer grouping: Level > IFC class.
+
+        Tier 1 walks the ON_LEVEL relation (group by storey); tier 2 groups by the
+        ``ifcType`` eav attribute (the IFC class). The consumer seeds its model-tree
+        grouping from this. The Level tier is omitted when the file has no storeys, so
+        the default degrades to grouping by class alone.
+        """
+        keys = []
+        if self._has_levels:
+            keys.append(SceneViewKey.rel(Rel.ON_LEVEL))
+        keys.append(SceneViewKey.eav("ifcType"))
+        self._pipeline.add_scene_view(
+            SceneView(view=0, name="Level / Class", is_default=True, keys=keys)
+        )
 
     def _emit_systems(self, root: Collection) -> None:
         for proxy in _attr(root, "systemProxies", []) or []:

--- a/src/speckleifc/bundle_exporter.py
+++ b/src/speckleifc/bundle_exporter.py
@@ -1,0 +1,233 @@
+"""Drives the Speckle 4.0 bundle producer from a converted IFC tree.
+
+The IFC ``ImportJob.convert()`` returns a root ``Collection`` whose scene tree
+(collections + DataObjects + InstanceProxy displayValues) and attached proxy lists
+(instanceDefinitionProxies / renderMaterialProxies / levelProxies / systemProxies /
+connectionProxies) map directly onto the envelope graph. This module performs that
+mapping via :class:`~specklepy.bundle.pipeline.ObjectsArtifactPipeline` — no re-reading of
+the IFC file; everything comes from the already-converted ``Base`` tree.
+
+Emission order matters: definitions (+ their geometries) and materials first, so the scene
+walk's instances and the material edges can reference the geometry/definition Ks already
+minted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from specklepy.bundle.pipeline import ObjectsArtifactPipeline
+from specklepy.objects.base import Base
+from specklepy.objects.data_objects import DataObject
+from specklepy.objects.geometry import Mesh
+from specklepy.objects.models.collections.collection import Collection
+
+_DEFINITION_GEOMETRY = "definitionGeometry"
+
+
+def _attr(node: Base, key: str, default: Any = None) -> Any:
+    """Read a typed or dynamic Base member, tolerating absence."""
+    try:
+        return node[key]
+    except (KeyError, AttributeError):
+        return getattr(node, key, default)
+
+
+class IfcBundleExporter:
+    """Translates a converted IFC root Collection into a bundle on disk."""
+
+    def __init__(self, output_dir: str, base_name: str) -> None:
+        self._pipeline = ObjectsArtifactPipeline(output_dir, base_name)
+        self._def_k_by_id: dict[str, int] = {}
+        self._object_count = 0
+
+    def export(self, root: Collection) -> tuple[str, int]:
+        """Emit the whole bundle. Returns ``(root_id, object_count)`` for the uploader."""
+        mesh_by_id = self._index_definition_geometry(root)
+
+        self._emit_definitions(root, mesh_by_id)
+        self._emit_materials(root)
+        self._walk(
+            root, parent_collection_k=None, parent_object_k=None, ord=0, is_root=True
+        )
+        self._emit_levels(root)
+        self._emit_systems(root)
+        self._emit_connections(root)
+
+        self._pipeline.complete()
+        root_id = _attr(root, "applicationId") or "root"
+        return root_id, self._object_count
+
+    # ── geometry / definitions ──────────────────────────────────────────────
+
+    def _index_definition_geometry(self, root: Collection) -> dict[str, Mesh]:
+        """Build {mesh.applicationId -> Mesh} from the appended ``definitionGeometry`` collection."""
+        index: dict[str, Mesh] = {}
+        for el in _attr(root, "elements", []) or []:
+            if isinstance(el, Collection) and _attr(el, "name") == _DEFINITION_GEOMETRY:
+                for mesh in _attr(el, "elements", []) or []:
+                    app_id = _attr(mesh, "applicationId")
+                    if app_id:
+                        index[app_id] = mesh
+        return index
+
+    def _emit_definitions(self, root: Collection, mesh_by_id: dict[str, Mesh]) -> None:
+        for proxy in _attr(root, "instanceDefinitionProxies", []) or []:
+            def_id = _attr(proxy, "applicationId")
+            if not def_id:
+                continue
+            def_k = self._pipeline.add_definition(def_id, _attr(proxy, "name"))
+            self._def_k_by_id[def_id] = def_k
+            for ordi, mesh_id in enumerate(_attr(proxy, "objects", []) or []):
+                mesh = mesh_by_id.get(mesh_id)
+                if mesh is None:
+                    continue
+                geo_k = self._pipeline.add_geometry(mesh_id, mesh)
+                self._pipeline.defines(def_k, geo_k, ordi)
+
+    def _emit_materials(self, root: Collection) -> None:
+        for proxy in _attr(root, "renderMaterialProxies", []) or []:
+            material = _attr(proxy, "value")
+            if material is None:
+                continue
+            mat_id = _attr(material, "applicationId") or _attr(material, "name") or ""
+            mat_k = self._pipeline.add_material(
+                mat_id,
+                argb=int(_attr(material, "diffuse", -1)),
+                opacity=float(_attr(material, "opacity", 1.0)),
+                metalness=float(_attr(material, "metalness", 0.0)),
+                roughness=float(_attr(material, "roughness", 1.0)),
+            )
+            for mesh_id in _attr(proxy, "objects", []) or []:
+                geo_k = self._pipeline.intern_geometry_id(mesh_id)
+                self._pipeline.has_material(geo_k, mat_k)
+
+    # ── scene tree ──────────────────────────────────────────────────────────
+
+    def _walk(
+        self,
+        node: Base,
+        parent_collection_k: int | None,
+        parent_object_k: int | None,
+        ord: int,
+        is_root: bool = False,
+    ) -> None:
+        if isinstance(node, Collection):
+            if _attr(node, "name") == _DEFINITION_GEOMETRY:
+                return  # definition geometry, not a scene container
+            coll_k = self._pipeline.add_collection(
+                _attr(node, "applicationId") or _attr(node, "name") or "collection",
+                _attr(node, "name"),
+                parent_collection_k,
+                _attr(node, "ifcType") or "Collection",
+            )
+            for i, child in enumerate(_attr(node, "elements", []) or []):
+                self._walk(child, coll_k, None, i)
+            return
+
+        if isinstance(node, DataObject):
+            app_id = _attr(node, "applicationId")
+            if not app_id:
+                return
+            obj_k = self._pipeline.intern_object(app_id)
+            self._object_count += 1
+            self._pipeline.add_properties(
+                app_id,
+                _attr(node, "properties", {}) or {},
+                root_scalars=[
+                    ("name", _attr(node, "name")),
+                    ("ifcType", _attr(node, "ifcType")),
+                ],
+            )
+
+            # membership: under a Collection -> IN_COLLECTION; under a DataObject -> SUBELEMENT.
+            if parent_object_k is not None:
+                self._pipeline.subelement(parent_object_k, obj_k, ord)
+            elif parent_collection_k is not None:
+                self._pipeline.in_collection(obj_k, parent_collection_k, ord)
+
+            self._emit_display(node, obj_k)
+
+            for i, child in enumerate(_attr(node, "@elements", []) or []):
+                self._walk(child, parent_collection_k, obj_k, i)
+            return
+
+        # Meshes / geometry primitives appearing inline are skipped (definition geometry
+        # is handled via the proxies above).
+
+    def _emit_display(self, node: DataObject, obj_k: int) -> None:
+        for i, ip in enumerate(_attr(node, "displayValue", []) or []):
+            def_id = _attr(ip, "definitionId")
+            def_k = self._def_k_by_id.get(def_id) if def_id else None
+            if def_k is None:
+                continue
+            inst_k = self._pipeline.add_instance(
+                _attr(ip, "applicationId") or f"{obj_k}:{i}",
+                def_k,
+                _attr(ip, "transform", []) or [],
+                _attr(ip, "units"),
+            )
+            self._pipeline.display_instance(obj_k, inst_k, i)
+
+    # ── levels / topology ─────────────────────────────────────────────────────
+
+    def _emit_levels(self, root: Collection) -> None:
+        for proxy in _attr(root, "levelProxies", []) or []:
+            level_id = _attr(proxy, "applicationId")
+            if not level_id:
+                continue
+            value = _attr(proxy, "value")
+            name = _attr(value, "name") if value is not None else None
+            lvl_k = self._pipeline.add_level(level_id, name, _elevation_of(value))
+            for member_id in _attr(proxy, "objects", []) or []:
+                obj_k = self._pipeline.intern_object(member_id)
+                self._pipeline.on_level(obj_k, lvl_k)
+
+    def _emit_systems(self, root: Collection) -> None:
+        for proxy in _attr(root, "systemProxies", []) or []:
+            system_id = _attr(proxy, "applicationId")
+            if not system_id:
+                continue
+            name = _attr(proxy, "name")
+            system_type = _attr(proxy, "systemType")
+            # Canonical container subtype stays "System" (cross-connector); the IFC PredefinedType
+            # rides on the display name so it isn't lost.
+            display = f"{name} ({system_type})" if system_type else name
+            sys_k = self._pipeline.add_container(system_id, display, None, "System")
+            for member_id in _attr(proxy, "objects", []) or []:
+                obj_k = self._pipeline.intern_object(member_id)
+                self._pipeline.in_system(obj_k, sys_k, 0)
+
+    def _emit_connections(self, root: Collection) -> None:
+        for proxy in _attr(root, "connectionProxies", []) or []:
+            source_id = _attr(proxy, "sourceAppId")
+            target_id = _attr(proxy, "targetAppId")
+            if not source_id or not target_id:
+                continue
+            src_k = self._pipeline.intern_object(source_id)
+            tgt_k = self._pipeline.intern_object(target_id)
+            src_flow = _attr(proxy, "sourceFlowDirection")
+            tgt_flow = _attr(proxy, "targetFlowDirection")
+
+            # Orient by FlowDirection: SOURCE->SINK is a directed edge (flip if reversed);
+            # anything else (SOURCEANDSINK / NOTDEFINED / missing) is undirected -> reciprocal pair.
+            if src_flow == "SOURCE" and tgt_flow == "SINK":
+                self._pipeline.connects_to(src_k, tgt_k)
+            elif src_flow == "SINK" and tgt_flow == "SOURCE":
+                self._pipeline.connects_to(tgt_k, src_k)
+            else:
+                self._pipeline.connects_to(src_k, tgt_k)
+                self._pipeline.connects_to(tgt_k, src_k)
+
+
+def _elevation_of(level_value: Base | None) -> float:
+    """Best-effort storey elevation from the level DataObject's IFC attributes."""
+    if level_value is None:
+        return 0.0
+    props = _attr(level_value, "properties", {}) or {}
+    attributes = props.get("Attributes", {}) if isinstance(props, dict) else {}
+    elevation = attributes.get("Elevation") if isinstance(attributes, dict) else None
+    try:
+        return float(elevation) if elevation is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/speckleifc/importer.py
+++ b/src/speckleifc/importer.py
@@ -34,8 +34,8 @@ class ImportJob:
     progress: IngestionProgressManager
 
     emit_topology: bool = False
-    """Attach MEP topology (systemProxies + connectionProxies) to the root. Off by default
-    so the v1 output is unchanged; the 4.0 bundle path turns it on."""
+    """Attach MEP topology (systemProxies + connectionProxies) to the root. Off by
+    default so the v1 output is unchanged; the 4.0 bundle path turns it on."""
 
     _render_material_manager: RenderMaterialProxyManager = field(
         default_factory=lambda: RenderMaterialProxyManager()

--- a/src/speckleifc/importer.py
+++ b/src/speckleifc/importer.py
@@ -33,6 +33,10 @@ class ImportJob:
 
     progress: IngestionProgressManager
 
+    emit_topology: bool = False
+    """Attach MEP topology (systemProxies + connectionProxies) to the root. Off by default
+    so the v1 output is unchanged; the 4.0 bundle path turns it on."""
+
     _render_material_manager: RenderMaterialProxyManager = field(
         default_factory=lambda: RenderMaterialProxyManager()
     )
@@ -241,15 +245,19 @@ class ImportJob:
             self._instance_proxy_manager.instance_definition_proxies.values()
         )
 
-        # Network topology: system membership + port-connectivity edges.
-        # Extracted directly from the IFC graph (global relationships, not
-        # per-element), so run once over the whole file here.
-        self._system_proxy_manager.extract(self.ifc_file)
-        self._connection_proxy_manager.extract(self.ifc_file)
-        tree["systemProxies"] = list(
-            self._system_proxy_manager.system_proxies.values()
-        )
-        tree["connectionProxies"] = self._connection_proxy_manager.connection_proxies
+        # Network topology: system membership + port-connectivity edges. Extracted
+        # directly from the IFC graph (global relationships, not per-element), so run
+        # once over the whole file here. Only for the 4.0 bundle path — leaving the v1
+        # output untouched (no systemProxies / connectionProxies keys).
+        if self.emit_topology:
+            self._system_proxy_manager.extract(self.ifc_file)
+            self._connection_proxy_manager.extract(self.ifc_file)
+            tree["systemProxies"] = list(
+                self._system_proxy_manager.system_proxies.values()
+            )
+            tree["connectionProxies"] = (
+                self._connection_proxy_manager.connection_proxies
+            )
         tree.elements.append(
             Collection(
                 name="definitionGeometry",

--- a/src/speckleifc/importer.py
+++ b/src/speckleifc/importer.py
@@ -12,11 +12,13 @@ from speckleifc.converter.project_converter import project_to_speckle
 from speckleifc.converter.spatial_element_converter import spatial_element_to_speckle
 from speckleifc.ifc_geometry_processing import create_geometry_iterator
 from speckleifc.ifc_openshell_helpers import get_children
+from speckleifc.proxy_managers.connection_proxy_manager import ConnectionProxyManager
 from speckleifc.proxy_managers.instance_proxy_manager import InstanceProxyManager
 from speckleifc.proxy_managers.level_proxy_manager import LevelProxyManager
 from speckleifc.proxy_managers.render_material_proxy_manager import (
     RenderMaterialProxyManager,
 )
+from speckleifc.proxy_managers.system_proxy_manager import SystemProxyManager
 from specklepy.logging.exceptions import SpeckleException
 from specklepy.objects import Base
 from specklepy.objects.data_objects import DataObject
@@ -39,6 +41,12 @@ class ImportJob:
     )
     _instance_proxy_manager: InstanceProxyManager = field(
         default_factory=lambda: InstanceProxyManager()
+    )
+    _system_proxy_manager: SystemProxyManager = field(
+        default_factory=lambda: SystemProxyManager()
+    )
+    _connection_proxy_manager: ConnectionProxyManager = field(
+        default_factory=lambda: ConnectionProxyManager()
     )
     geometries_count: int = 0
     geometries_used: int = 0
@@ -232,6 +240,16 @@ class ImportJob:
         tree["instanceDefinitionProxies"] = list(
             self._instance_proxy_manager.instance_definition_proxies.values()
         )
+
+        # Network topology: system membership + port-connectivity edges.
+        # Extracted directly from the IFC graph (global relationships, not
+        # per-element), so run once over the whole file here.
+        self._system_proxy_manager.extract(self.ifc_file)
+        self._connection_proxy_manager.extract(self.ifc_file)
+        tree["systemProxies"] = list(
+            self._system_proxy_manager.system_proxies.values()
+        )
+        tree["connectionProxies"] = self._connection_proxy_manager.connection_proxies
         tree.elements.append(
             Collection(
                 name="definitionGeometry",

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -1,12 +1,15 @@
 import contextlib
 import importlib.metadata
 import os
+import tempfile
 import time
 import traceback
 from pathlib import Path
 
+from speckleifc.bundle_exporter import IfcBundleExporter
 from speckleifc.ifc_geometry_processing import open_ifc
 from speckleifc.importer import ImportJob
+from specklepy.bundle.upload import ArtifactPipeline
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionFailedInput,
@@ -157,10 +160,16 @@ def _fetch_pre_allocated_version_id(
 ) -> str | None:
     """Read the ingestion's pre-allocated ``versionId`` (a v2-only top-level field).
 
-    Done with a dedicated GraphQL query rather than the shared model_ingestion resource:
-    ``ModelIngestion.versionId`` only exists on servers with the v2 data endpoints, so
-    selecting it in the SDK's standard ingestion queries would break older servers.
-    Runs only on the bundle path (which targets a v2 server), so it is safe here.
+    Uses the TOP-LEVEL ``ModelIngestion.versionId``, not the ``versionId`` under
+    ``statusData → ModelIngestionSuccessStatus``: that one is only populated once the
+    ingestion has SUCCEEDED, but we need the id up-front (to name/reference the version
+    before uploading), when the status is still PROCESSING and the success fragment is
+    null.
+
+    Done with a dedicated GraphQL query rather than the shared model_ingestion resource
+    because the top-level ``versionId`` field only exists on servers with the v2 data
+    endpoints — selecting it in the SDK's standard ingestion queries breaks older
+    servers. This runs only on the bundle path (a v2 server), so it is safe here.
     """
     import httpx
 
@@ -194,17 +203,9 @@ def _upload_bundle(
 ) -> Version:
     """Build the Speckle 4.0 artefact bundle and upload it via the v2 data endpoints.
 
-    Opt-in via SPECKLE_IFC_BUNDLE. Imports the bundle producer lazily so the default v1
-    path never pulls pyarrow/duckdb (the ``specklepy[bundle]`` extra). The version is
-    created server-side by the v2 ``complete`` call (no v1
-    ``model_ingestion.complete``).
+    Opt-in via SPECKLE_IFC_BUNDLE. The version is created server-side by the v2
+    ``complete`` call (no v1 ``model_ingestion.complete``).
     """
-    # Lazy: keeps pyarrow/duckdb out of the import graph on the v1 path.
-    import tempfile
-
-    from speckleifc.bundle_exporter import IfcBundleExporter
-    from specklepy.bundle.upload import ArtifactPipeline
-
     version_id = _fetch_pre_allocated_version_id(
         account, project.id, model_ingestion_id
     )

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -14,7 +14,7 @@ from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionSuccessInput,
     SourceDataInput,
 )
-from specklepy.core.api.models.current import ModelIngestion, Project, Version
+from specklepy.core.api.models.current import Project, Version
 from specklepy.core.api.operations import send
 from specklepy.logging import metrics
 from specklepy.logging.exceptions import SpeckleException
@@ -27,8 +27,8 @@ from specklepy.transports.server import ServerTransport
 # We could maybe go a little lower, but for now I'm not risking degrading performance
 PROGRESS_INTERVAL_SECONDS = 10
 
-# Opt in to the Speckle 4.0 artefact bundle (parquet eav + envelope + geometries, uploaded
-# via the v2 data endpoints) by setting SPECKLE_IFC_BUNDLE=1. Default is the v1
+# Opt in to the Speckle 4.0 artefact bundle (parquet eav + envelope + geometries,
+# uploaded via the v2 data endpoints) by setting SPECKLE_IFC_BUNDLE=1. Default is the v1
 # detached-object send, whose behaviour is unchanged. Only flip where the target server
 # exposes the v2 data endpoints AND the viewer reads bundles.
 _BUNDLE_ENV_VAR = "SPECKLE_IFC_BUNDLE"
@@ -76,8 +76,8 @@ def open_and_convert_file(
         progress.report("Opening file", None)
         ifc_file = open_ifc(file_path)  # pyright: ignore[reportUnknownVariableType]
 
-        # Topology (system membership + port connectivity) is attached only for the bundle
-        # path; the v1 output is left exactly as before.
+        # Topology (system membership + port connectivity) is attached only for the
+        # bundle path; the v1 output is left exactly as before.
         import_job = ImportJob(ifc_file, progress, emit_topology=bundle)  # pyright: ignore[reportUnknownArgumentType]
         data = import_job.convert()
 
@@ -89,7 +89,7 @@ def open_and_convert_file(
 
         if bundle:
             version = _upload_bundle(
-                client, project, account, model_ingestion_id, ingestion, data, progress
+                client, project, account, model_ingestion_id, data, progress
             )
         else:
             progress.report("Uploading objects", None)
@@ -152,12 +152,43 @@ def open_and_convert_file(
         raise e
 
 
+def _fetch_pre_allocated_version_id(
+    account, project_id: str, model_ingestion_id: str
+) -> str | None:
+    """Read the ingestion's pre-allocated ``versionId`` (a v2-only top-level field).
+
+    Done with a dedicated GraphQL query rather than the shared model_ingestion resource:
+    ``ModelIngestion.versionId`` only exists on servers with the v2 data endpoints, so
+    selecting it in the SDK's standard ingestion queries would break older servers.
+    Runs only on the bundle path (which targets a v2 server), so it is safe here.
+    """
+    import httpx
+
+    url = account.serverInfo.url.rstrip("/") + "/graphql"
+    headers = {"Authorization": f"Bearer {account.token}"} if account.token else {}
+    query = (
+        "query($p:String!,$i:ID!){ project(id:$p){ ingestion(id:$i){ versionId } } }"
+    )
+    resp = httpx.post(
+        url,
+        headers=headers,
+        json={"query": query, "variables": {"p": project_id, "i": model_ingestion_id}},
+        timeout=60,
+    )
+    body = resp.json()
+    if body.get("errors"):
+        raise SpeckleException(
+            f"Failed to fetch pre-allocated version id: {body['errors']}"
+        )
+    ingestion = ((body.get("data") or {}).get("project") or {}).get("ingestion") or {}
+    return ingestion.get("versionId")
+
+
 def _upload_bundle(
     client: SpeckleClient,
     project: Project,
     account,
     model_ingestion_id: str,
-    ingestion: ModelIngestion,
     data,
     progress: IngestionProgressManager,
 ) -> Version:
@@ -165,7 +196,8 @@ def _upload_bundle(
 
     Opt-in via SPECKLE_IFC_BUNDLE. Imports the bundle producer lazily so the default v1
     path never pulls pyarrow/duckdb (the ``specklepy[bundle]`` extra). The version is
-    created server-side by the v2 ``complete`` call (no v1 ``model_ingestion.complete``).
+    created server-side by the v2 ``complete`` call (no v1
+    ``model_ingestion.complete``).
     """
     # Lazy: keeps pyarrow/duckdb out of the import graph on the v1 path.
     import tempfile
@@ -173,7 +205,9 @@ def _upload_bundle(
     from speckleifc.bundle_exporter import IfcBundleExporter
     from specklepy.bundle.upload import ArtifactPipeline
 
-    version_id = ingestion.version_id
+    version_id = _fetch_pre_allocated_version_id(
+        account, project.id, model_ingestion_id
+    )
     if not version_id:
         raise SpeckleException(
             "Model ingestion returned no pre-allocated version id — the server must "

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -1,24 +1,24 @@
 import contextlib
 import importlib.metadata
-import tempfile
 import time
 import traceback
 from pathlib import Path
 
-from speckleifc.bundle_exporter import IfcBundleExporter
 from speckleifc.ifc_geometry_processing import open_ifc
 from speckleifc.importer import ImportJob
-from specklepy.bundle.upload import ArtifactPipeline
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionFailedInput,
     ModelIngestionStartProcessingInput,
+    ModelIngestionSuccessInput,
     SourceDataInput,
 )
 from specklepy.core.api.models.current import Project, Version
+from specklepy.core.api.operations import send
 from specklepy.logging import metrics
-from specklepy.logging.exceptions import SpeckleException
 from specklepy.progress.ingestion_progress import IngestionProgressManager
+from specklepy.progress.progress_transport import ProgressTransport
+from specklepy.transports.server import ServerTransport
 
 # Since progress messages are currently blocking (no async), we're being extra coarse
 # with progress updates to ensure we're not waisting time sending updates.
@@ -58,13 +58,10 @@ def open_and_convert_file(
         account = client.account
         server_url = account.serverInfo.url
         assert server_url
-        # The version id is pre-allocated by the server at ingestion creation; the 4.0
-        # artefact bundle is uploaded under it via the v2 data endpoints (see below).
-        version_id = ingestion.status_data.version_id
-        if not version_id:
-            raise SpeckleException(
-                "Ingestion did not return a pre-allocated version id"
-            )
+        remote_transport = ServerTransport(project.id, account=account)
+        progress_transport = ProgressTransport(
+            progress,
+        )
 
         progress.report("Opening file", None)
         ifc_file = open_ifc(file_path)  # pyright: ignore[reportUnknownVariableType]
@@ -78,27 +75,63 @@ def open_and_convert_file(
 
         start = time.time()
 
-        # Speckle 4.0: build the artefact bundle (eav + envelope + geometries parquet) from
-        # the converted tree, then upload it via the v2 data endpoints (sign -> PUT -> complete,
-        # which creates the version). Replaces the v1 detached-object send entirely.
-        progress.report("Writing bundle", None)
-        with tempfile.TemporaryDirectory(prefix="speckle-bundle-") as bundle_dir:
-            exporter = IfcBundleExporter(bundle_dir, version_id)
-            root_id, total_children_count = exporter.export(data)
-            print(
-                f"Bundle written after: {(time.time() - start):.3f}s"  # noqa: E501
-            )
+        # ──────────────────────────────────────────────────────────────────
+        # SPECKLE 4.0 BUNDLE PATH — DISABLED (default is the v1 send below).
+        #
+        # When ready, swap this in PLACE OF the v1 "Uploading objects" → version
+        # block below (or gate both on an env var, e.g.
+        #   if os.environ.get("SPECKLE_IFC_BUNDLE") == "1": <bundle> else <v1>).
+        # It builds the parquet artefact bundle from the converted tree and
+        # uploads it via the v2 data endpoints (sign → PUT → complete), instead
+        # of v1 detached objects. Kept off so this merge is purely additive —
+        # flip only once the importer's target server exposes the v2 endpoints
+        # AND the viewer reads bundles.
+        #
+        # Requires the `specklepy[bundle]` extra (pyarrow/duckdb) and imports:
+        #   import os, tempfile
+        #   from speckleifc.bundle_exporter import IfcBundleExporter
+        #   from specklepy.bundle.upload import ArtifactPipeline
+        #   from specklepy.logging.exceptions import SpeckleException
+        #
+        # GOTCHA — the pre-allocated version id is the TOP-LEVEL
+        # ModelIngestion.versionId GraphQL field. The SDK's model_ingestion
+        # resource does NOT select it today (ingestion.status_data.version_id is
+        # None), so fetch it via a direct GraphQL query (or extend the resource +
+        # ModelIngestion model) before enabling.
+        #
+        # version_id = ingestion.version_id  # once the resource selects it
+        # if not version_id:
+        #     raise SpeckleException("Ingestion has no pre-allocated version id")
+        # progress.report("Writing bundle", None)
+        # with tempfile.TemporaryDirectory(prefix="speckle-bundle-") as bdir:
+        #     root_id, child_count = IfcBundleExporter(bdir, version_id).export(data)
+        #     progress.report("Uploading bundle", None)
+        #     with ArtifactPipeline(
+        #         project.id, model_ingestion_id, version_id, account, bdir
+        #     ) as pipeline:
+        #         version_id = pipeline.upload_dir(version_id, root_id, child_count)
+        # version = client.version.get(version_id, project.id)
+        # ──────────────────────────────────────────────────────────────────
 
-            start = time.time()
-            progress.report("Uploading bundle", None)
-            with ArtifactPipeline(
-                project.id, model_ingestion_id, version_id, account, bundle_dir
-            ) as pipeline:
-                version_id = pipeline.upload_dir(
-                    version_id, root_id, total_children_count
-                )
+        progress.report("Uploading objects", None)
+        root_id = send(
+            data,
+            transports=[remote_transport, progress_transport],
+            use_default_cache=False,
+        )
         print(
-            f"Uploading bundle complete after: {(time.time() - start):.3f}s"  # noqa: E501
+            f"Sending to speckle complete after: {(time.time() - start):.3f}s"  # noqa: E501
+        )
+
+        start = time.time()
+
+        version_id = client.model_ingestion.complete(
+            ModelIngestionSuccessInput(
+                project_id=project.id,
+                ingestion_id=model_ingestion_id,
+                root_object_id=root_id,
+                version_message=version_message,
+            )
         )
 
         # needed to query version until ingestion api expands to serve it

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib.metadata
+import os
 import time
 import traceback
 from pathlib import Path
@@ -13,9 +14,10 @@ from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionSuccessInput,
     SourceDataInput,
 )
-from specklepy.core.api.models.current import Project, Version
+from specklepy.core.api.models.current import ModelIngestion, Project, Version
 from specklepy.core.api.operations import send
 from specklepy.logging import metrics
+from specklepy.logging.exceptions import SpeckleException
 from specklepy.progress.ingestion_progress import IngestionProgressManager
 from specklepy.progress.progress_transport import ProgressTransport
 from specklepy.transports.server import ServerTransport
@@ -24,6 +26,16 @@ from specklepy.transports.server import ServerTransport
 # with progress updates to ensure we're not waisting time sending updates.
 # We could maybe go a little lower, but for now I'm not risking degrading performance
 PROGRESS_INTERVAL_SECONDS = 10
+
+# Opt in to the Speckle 4.0 artefact bundle (parquet eav + envelope + geometries, uploaded
+# via the v2 data endpoints) by setting SPECKLE_IFC_BUNDLE=1. Default is the v1
+# detached-object send, whose behaviour is unchanged. Only flip where the target server
+# exposes the v2 data endpoints AND the viewer reads bundles.
+_BUNDLE_ENV_VAR = "SPECKLE_IFC_BUNDLE"
+
+
+def _bundle_enabled() -> bool:
+    return os.environ.get(_BUNDLE_ENV_VAR, "").strip().lower() in ("1", "true", "yes")
 
 
 def open_and_convert_file(
@@ -58,15 +70,15 @@ def open_and_convert_file(
         account = client.account
         server_url = account.serverInfo.url
         assert server_url
-        remote_transport = ServerTransport(project.id, account=account)
-        progress_transport = ProgressTransport(
-            progress,
-        )
+
+        bundle = _bundle_enabled()
 
         progress.report("Opening file", None)
         ifc_file = open_ifc(file_path)  # pyright: ignore[reportUnknownVariableType]
 
-        import_job = ImportJob(ifc_file, progress)  # pyright: ignore[reportUnknownArgumentType]
+        # Topology (system membership + port connectivity) is attached only for the bundle
+        # path; the v1 output is left exactly as before.
+        import_job = ImportJob(ifc_file, progress, emit_topology=bundle)  # pyright: ignore[reportUnknownArgumentType]
         data = import_job.convert()
 
         print(
@@ -75,67 +87,36 @@ def open_and_convert_file(
 
         start = time.time()
 
-        # ──────────────────────────────────────────────────────────────────
-        # SPECKLE 4.0 BUNDLE PATH — DISABLED (default is the v1 send below).
-        #
-        # When ready, swap this in PLACE OF the v1 "Uploading objects" → version
-        # block below (or gate both on an env var, e.g.
-        #   if os.environ.get("SPECKLE_IFC_BUNDLE") == "1": <bundle> else <v1>).
-        # It builds the parquet artefact bundle from the converted tree and
-        # uploads it via the v2 data endpoints (sign → PUT → complete), instead
-        # of v1 detached objects. Kept off so this merge is purely additive —
-        # flip only once the importer's target server exposes the v2 endpoints
-        # AND the viewer reads bundles.
-        #
-        # Requires the `specklepy[bundle]` extra (pyarrow/duckdb) and imports:
-        #   import os, tempfile
-        #   from speckleifc.bundle_exporter import IfcBundleExporter
-        #   from specklepy.bundle.upload import ArtifactPipeline
-        #   from specklepy.logging.exceptions import SpeckleException
-        #
-        # GOTCHA — the pre-allocated version id is the TOP-LEVEL
-        # ModelIngestion.versionId GraphQL field. The SDK's model_ingestion
-        # resource does NOT select it today (ingestion.status_data.version_id is
-        # None), so fetch it via a direct GraphQL query (or extend the resource +
-        # ModelIngestion model) before enabling.
-        #
-        # version_id = ingestion.version_id  # once the resource selects it
-        # if not version_id:
-        #     raise SpeckleException("Ingestion has no pre-allocated version id")
-        # progress.report("Writing bundle", None)
-        # with tempfile.TemporaryDirectory(prefix="speckle-bundle-") as bdir:
-        #     root_id, child_count = IfcBundleExporter(bdir, version_id).export(data)
-        #     progress.report("Uploading bundle", None)
-        #     with ArtifactPipeline(
-        #         project.id, model_ingestion_id, version_id, account, bdir
-        #     ) as pipeline:
-        #         version_id = pipeline.upload_dir(version_id, root_id, child_count)
-        # version = client.version.get(version_id, project.id)
-        # ──────────────────────────────────────────────────────────────────
-
-        progress.report("Uploading objects", None)
-        root_id = send(
-            data,
-            transports=[remote_transport, progress_transport],
-            use_default_cache=False,
-        )
-        print(
-            f"Sending to speckle complete after: {(time.time() - start):.3f}s"  # noqa: E501
-        )
-
-        start = time.time()
-
-        version_id = client.model_ingestion.complete(
-            ModelIngestionSuccessInput(
-                project_id=project.id,
-                ingestion_id=model_ingestion_id,
-                root_object_id=root_id,
-                version_message=version_message,
+        if bundle:
+            version = _upload_bundle(
+                client, project, account, model_ingestion_id, ingestion, data, progress
             )
-        )
+        else:
+            progress.report("Uploading objects", None)
+            remote_transport = ServerTransport(project.id, account=account)
+            progress_transport = ProgressTransport(progress)
+            root_id = send(
+                data,
+                transports=[remote_transport, progress_transport],
+                use_default_cache=False,
+            )
+            print(
+                f"Sending to speckle complete after: {(time.time() - start):.3f}s"  # noqa: E501
+            )
 
-        # needed to query version until ingestion api expands to serve it
-        version = client.version.get(version_id, project.id)
+            start = time.time()
+
+            version_id = client.model_ingestion.complete(
+                ModelIngestionSuccessInput(
+                    project_id=project.id,
+                    ingestion_id=model_ingestion_id,
+                    root_object_id=root_id,
+                    version_message=version_message,
+                )
+            )
+
+            # needed to query version until ingestion api expands to serve it
+            version = client.version.get(version_id, project.id)
 
         end = time.time()
         print(f"Version committed after: {(end - start):.3f}s")
@@ -169,3 +150,44 @@ def open_and_convert_file(
                 )
             )
         raise e
+
+
+def _upload_bundle(
+    client: SpeckleClient,
+    project: Project,
+    account,
+    model_ingestion_id: str,
+    ingestion: ModelIngestion,
+    data,
+    progress: IngestionProgressManager,
+) -> Version:
+    """Build the Speckle 4.0 artefact bundle and upload it via the v2 data endpoints.
+
+    Opt-in via SPECKLE_IFC_BUNDLE. Imports the bundle producer lazily so the default v1
+    path never pulls pyarrow/duckdb (the ``specklepy[bundle]`` extra). The version is
+    created server-side by the v2 ``complete`` call (no v1 ``model_ingestion.complete``).
+    """
+    # Lazy: keeps pyarrow/duckdb out of the import graph on the v1 path.
+    import tempfile
+
+    from speckleifc.bundle_exporter import IfcBundleExporter
+    from specklepy.bundle.upload import ArtifactPipeline
+
+    version_id = ingestion.version_id
+    if not version_id:
+        raise SpeckleException(
+            "Model ingestion returned no pre-allocated version id — the server must "
+            f"support the v2 data endpoints to use {_BUNDLE_ENV_VAR}."
+        )
+
+    progress.report("Writing bundle", None)
+    with tempfile.TemporaryDirectory(prefix="speckle-bundle-") as bundle_dir:
+        root_id, child_count = IfcBundleExporter(bundle_dir, version_id).export(data)
+        progress.report("Uploading bundle", None)
+        with ArtifactPipeline(
+            project.id, model_ingestion_id, version_id, account, bundle_dir
+        ) as pipeline:
+            version_id = pipeline.upload_dir(version_id, root_id, child_count)
+
+    # needed to query version until ingestion api expands to serve it
+    return client.version.get(version_id, project.id)

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -1,24 +1,24 @@
 import contextlib
 import importlib.metadata
+import tempfile
 import time
 import traceback
 from pathlib import Path
 
+from speckleifc.bundle_exporter import IfcBundleExporter
 from speckleifc.ifc_geometry_processing import open_ifc
 from speckleifc.importer import ImportJob
+from specklepy.bundle.upload import ArtifactPipeline
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionFailedInput,
     ModelIngestionStartProcessingInput,
-    ModelIngestionSuccessInput,
     SourceDataInput,
 )
 from specklepy.core.api.models.current import Project, Version
-from specklepy.core.api.operations import send
 from specklepy.logging import metrics
+from specklepy.logging.exceptions import SpeckleException
 from specklepy.progress.ingestion_progress import IngestionProgressManager
-from specklepy.progress.progress_transport import ProgressTransport
-from specklepy.transports.server import ServerTransport
 
 # Since progress messages are currently blocking (no async), we're being extra coarse
 # with progress updates to ensure we're not waisting time sending updates.
@@ -58,10 +58,13 @@ def open_and_convert_file(
         account = client.account
         server_url = account.serverInfo.url
         assert server_url
-        remote_transport = ServerTransport(project.id, account=account)
-        progress_transport = ProgressTransport(
-            progress,
-        )
+        # The version id is pre-allocated by the server at ingestion creation; the 4.0
+        # artefact bundle is uploaded under it via the v2 data endpoints (see below).
+        version_id = ingestion.status_data.version_id
+        if not version_id:
+            raise SpeckleException(
+                "Ingestion did not return a pre-allocated version id"
+            )
 
         progress.report("Opening file", None)
         ifc_file = open_ifc(file_path)  # pyright: ignore[reportUnknownVariableType]
@@ -75,25 +78,27 @@ def open_and_convert_file(
 
         start = time.time()
 
-        progress.report("Uploading objects", None)
-        root_id = send(
-            data,
-            transports=[remote_transport, progress_transport],
-            use_default_cache=False,
-        )
-        print(
-            f"Sending to speckle complete after: {(time.time() - start):.3f}s"  # noqa: E501
-        )
-
-        start = time.time()
-
-        version_id = client.model_ingestion.complete(
-            ModelIngestionSuccessInput(
-                project_id=project.id,
-                ingestion_id=model_ingestion_id,
-                root_object_id=root_id,
-                version_message=version_message,
+        # Speckle 4.0: build the artefact bundle (eav + envelope + geometries parquet) from
+        # the converted tree, then upload it via the v2 data endpoints (sign -> PUT -> complete,
+        # which creates the version). Replaces the v1 detached-object send entirely.
+        progress.report("Writing bundle", None)
+        with tempfile.TemporaryDirectory(prefix="speckle-bundle-") as bundle_dir:
+            exporter = IfcBundleExporter(bundle_dir, version_id)
+            root_id, total_children_count = exporter.export(data)
+            print(
+                f"Bundle written after: {(time.time() - start):.3f}s"  # noqa: E501
             )
+
+            start = time.time()
+            progress.report("Uploading bundle", None)
+            with ArtifactPipeline(
+                project.id, model_ingestion_id, version_id, account, bundle_dir
+            ) as pipeline:
+                version_id = pipeline.upload_dir(
+                    version_id, root_id, total_children_count
+                )
+        print(
+            f"Uploading bundle complete after: {(time.time() - start):.3f}s"  # noqa: E501
         )
 
         # needed to query version until ingestion api expands to serve it

--- a/src/speckleifc/proxy_managers/connection_proxy_manager.py
+++ b/src/speckleifc/proxy_managers/connection_proxy_manager.py
@@ -56,8 +56,6 @@ class ConnectionProxyManager:
                     sourceFlowDirection=getattr(
                         rel.RelatingPort, "FlowDirection", None
                     ),
-                    targetFlowDirection=getattr(
-                        rel.RelatedPort, "FlowDirection", None
-                    ),
+                    targetFlowDirection=getattr(rel.RelatedPort, "FlowDirection", None),
                 )
             )

--- a/src/speckleifc/proxy_managers/connection_proxy_manager.py
+++ b/src/speckleifc/proxy_managers/connection_proxy_manager.py
@@ -1,0 +1,63 @@
+from ifcopenshell import file
+from ifcopenshell.entity_instance import entity_instance
+
+from specklepy.objects.proxies import ConnectionProxy
+
+
+class ConnectionProxyManager:
+    """
+    Builds ConnectionProxies from IFC port connectivity.
+
+    Distribution elements (pipes, fittings, terminals) carry
+    ``IfcDistributionPort`` nodes, and ``IfcRelConnectsPorts`` links a pair of
+    ports. Resolving each port back to its owning element (via the nesting
+    relationship, or the legacy port-to-element relationship) yields the
+    element-level network graph: one ConnectionProxy per edge.
+    """
+
+    def __init__(self):
+        self._connection_proxies: list[ConnectionProxy] = []
+
+    @property
+    def connection_proxies(self) -> list[ConnectionProxy]:
+        return self._connection_proxies
+
+    @staticmethod
+    def _owner_of_port(port: entity_instance | None) -> entity_instance | None:
+        if port is None:
+            return None
+        # IFC4: port nested under its element via IfcRelNests (inverse: Nests)
+        for rel in getattr(port, "Nests", None) or []:
+            if rel.RelatingObject is not None:
+                return rel.RelatingObject
+        # Legacy: IfcRelConnectsPortToElement (inverse: ContainedIn)
+        for rel in getattr(port, "ContainedIn", None) or []:
+            if getattr(rel, "RelatedElement", None) is not None:
+                return rel.RelatedElement
+        return None
+
+    def extract(self, ifc_file: file) -> None:
+        for rel in ifc_file.by_type("IfcRelConnectsPorts"):
+            source = self._owner_of_port(rel.RelatingPort)
+            target = self._owner_of_port(rel.RelatedPort)
+            if source is None or target is None:
+                continue
+
+            source_id = getattr(source, "GlobalId", None)
+            target_id = getattr(target, "GlobalId", None)
+            if not source_id or not target_id:
+                continue
+
+            self._connection_proxies.append(
+                ConnectionProxy(
+                    sourceAppId=source_id,
+                    targetAppId=target_id,
+                    applicationId=getattr(rel, "GlobalId", None),
+                    sourceFlowDirection=getattr(
+                        rel.RelatingPort, "FlowDirection", None
+                    ),
+                    targetFlowDirection=getattr(
+                        rel.RelatedPort, "FlowDirection", None
+                    ),
+                )
+            )

--- a/src/speckleifc/proxy_managers/system_proxy_manager.py
+++ b/src/speckleifc/proxy_managers/system_proxy_manager.py
@@ -1,0 +1,58 @@
+from ifcopenshell import file
+from ifcopenshell.entity_instance import entity_instance
+
+from specklepy.objects.proxies import SystemProxy
+
+
+class SystemProxyManager:
+    """
+    Builds SystemProxies from IFC system grouping.
+
+    IFC groups distribution-network elements into ``IfcSystem`` /
+    ``IfcDistributionSystem`` via ``IfcRelAssignsToGroup``. Each such group
+    becomes one SystemProxy listing its member application ids, so the EAV
+    ingestion can denormalise system membership onto each element.
+    """
+
+    def __init__(self):
+        self._system_proxies: dict[str, SystemProxy] = {}
+
+    @property
+    def system_proxies(self) -> dict[str, SystemProxy]:
+        return self._system_proxies
+
+    def extract(self, ifc_file: file) -> None:
+        for rel in ifc_file.by_type("IfcRelAssignsToGroup"):
+            group: entity_instance | None = rel.RelatingGroup
+            if group is None:
+                continue
+            if not (group.is_a("IfcSystem") or group.is_a("IfcDistributionSystem")):
+                continue
+
+            group_id = getattr(group, "GlobalId", None)
+            if not group_id:
+                continue
+
+            members = [
+                o.GlobalId
+                for o in (rel.RelatedObjects or [])
+                if getattr(o, "GlobalId", None)
+            ]
+            if not members:
+                continue
+
+            existing = self._system_proxies.get(group_id)
+            if existing is not None:
+                # Same system can be assigned in multiple relationships
+                existing.objects.extend(members)
+                continue
+
+            system_type = getattr(group, "PredefinedType", None) or getattr(
+                group, "ObjectType", None
+            )
+            self._system_proxies[group_id] = SystemProxy(
+                objects=members,
+                name=group.Name or group_id,
+                applicationId=group_id,
+                systemType=system_type,
+            )

--- a/src/specklepy/bundle/__init__.py
+++ b/src/specklepy/bundle/__init__.py
@@ -1,0 +1,20 @@
+"""Speckle 4.0 bundle producer (eav + envelope + geometries parquet).
+
+Optional feature — requires ``specklepy[bundle]`` (pyarrow). The vocabulary and parquet
+schemas are sourced from the generated, vendored :mod:`specklepy.bundle.spec` (single source
+of truth: the ``speckle-bundle-spec`` repo). The typed producer API is
+:class:`~specklepy.bundle.pipeline.ObjectsArtifactPipeline`; upload via
+:class:`~specklepy.bundle.upload.ArtifactPipeline`.
+"""
+
+from specklepy.bundle.pipeline import ObjectsArtifactPipeline
+from specklepy.bundle.spec import SCHEMA_VERSION, NodeKind, Rel
+from specklepy.bundle.upload import ArtifactPipeline
+
+__all__ = [
+    "ObjectsArtifactPipeline",
+    "ArtifactPipeline",
+    "NodeKind",
+    "Rel",
+    "SCHEMA_VERSION",
+]

--- a/src/specklepy/bundle/__init__.py
+++ b/src/specklepy/bundle/__init__.py
@@ -1,8 +1,9 @@
 """Speckle 4.0 bundle producer (eav + envelope + geometries parquet).
 
-Optional feature — requires ``specklepy[bundle]`` (pyarrow). The vocabulary and parquet
-schemas are sourced from the generated, vendored :mod:`specklepy.bundle.spec` (single source
-of truth: the ``speckle-bundle-spec`` repo). The typed producer API is
+Optional feature — requires ``specklepy[bundle]`` (pyarrow). The vocabulary and
+parquet schemas are sourced from the generated, vendored
+:mod:`specklepy.bundle.spec` (single source of truth: the ``speckle-bundle-spec``
+repo). The typed producer API is
 :class:`~specklepy.bundle.pipeline.ObjectsArtifactPipeline`; upload via
 :class:`~specklepy.bundle.upload.ArtifactPipeline`.
 """

--- a/src/specklepy/bundle/eav_extraction.py
+++ b/src/specklepy/bundle/eav_extraction.py
@@ -1,0 +1,539 @@
+"""EAV (Entity-Attribute-Value) property extraction for the bundle producer.
+
+Ported from the .NET SDK's
+``Speckle.Sdk/Pipelines/Send/Artifacts/EavExtraction.cs`` (itself a port of the
+server's ``packages/shared/src/filtering/eavExtraction.ts``). Behaviour-parity
+with the TS/C# implementations is the goal — quirks are intentionally preserved.
+
+Unlike the C# JObject path, the Python input is an already-parsed
+``dict[str, Any]`` tree (the IFC converter builds ``DataObject.properties`` as
+nested dicts), so this mirrors the C# *native* (``Dictionary``) flatten path:
+``WalkPropertiesNative`` / ``FlattenProperties`` / ``FlattenSubtree``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, NamedTuple
+
+MAX_DEPTH = 10
+"""Recursion cutoff for the property walk (EavExtraction.cs:31)."""
+
+
+class EavRow(NamedTuple):
+    """One flat property row destined for the eav table (EavExtraction.cs:12-20)."""
+
+    object_id: str
+    path: str
+    value_text: str
+    value_num: float | None
+    type: str  # "string" | "number" | "boolean"
+    units: str | None
+    internal_definition_name: str | None
+
+
+# Universal top-level keys under `properties` excluded for every source
+# (EavExtraction.cs:42-46).
+DEFAULT_EXCLUDED_TOP_LEVEL: frozenset[str] = frozenset(
+    {"Autodesk Material", "Document"}
+)
+
+# Revit-specific top-level categories to skip (EavExtraction.cs:59-73). Exposed
+# for parity even though IFC won't use it.
+REVIT_EXCLUDED_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        "Line Style",
+        "SketchPlane",
+        "GeometryCurve",
+        "Element ID",
+        "Category",
+        "CreatedPhaseId",
+        "Id",
+        "Material",
+        "Revit Material",
+        "Orientation",
+        "ParametersMap",
+        "Phase Created",
+    }
+)
+
+# Root-level fields to index (outside of `properties`) (EavExtraction.cs:76-89).
+ROOT_SCALAR_FIELDS: tuple[str, ...] = (
+    "name",
+    "type",
+    "family",
+    "category",
+    "level",
+    "units",
+    "speckle_type",
+    "applicationId",
+    "definitionId",
+    "ifcType",
+    "path",
+)
+
+# Rejects UUID-like strings ("a-b-c" shapes) from numeric inference
+# (EavExtraction.cs:92).
+_UUID_LIKE = re.compile(r".-.-")
+
+
+# ───────────────────────────── scalar helpers ──────────────────────────────
+
+
+def _is_scalar(value: Any) -> bool:
+    """Mirror IsScalar (EavExtraction.cs:775). In Python ``bool`` subclasses
+    ``int``, so it is covered here and dispatched first everywhere below."""
+    return isinstance(value, bool | int | float | str)
+
+
+def _try_parse_float(text: str) -> float | None:
+    """C# ``double.TryParse(.., NumberStyles.Float, InvariantCulture)`` analogue.
+
+    ``NumberStyles.Float`` allows leading/trailing whitespace, sign, decimal
+    point and exponent — which ``float()`` also accepts. It does NOT allow digit
+    group separators, so reject Python's ``_`` grouping. ``inf``/``nan`` strings
+    are accepted by both but later rejected by the IsFinite guard at the caller.
+    """
+    if "_" in text:
+        return None
+    try:
+        return float(text)
+    except (ValueError, TypeError):
+        return None
+
+
+def _infer_type(value: Any) -> str:
+    """Port of InferTypeNative (EavExtraction.cs:797-828)."""
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, float):
+        return "number" if math.isfinite(value) else "string"
+    if isinstance(value, int):
+        return "number"
+    if isinstance(value, str):
+        if value.lower() in ("true", "false"):
+            return "boolean"
+        trimmed = value.strip()
+        if not trimmed or _UUID_LIKE.search(trimmed):
+            return "string"
+        num = _try_parse_float(trimmed)
+        return "number" if num is not None and math.isfinite(num) else "string"
+    return "string"
+
+
+def _to_num(value: Any) -> float | None:
+    """Port of ToNumNative (EavExtraction.cs:830-846). Only called when the
+    inferred type is ``"number"``."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        d = float(value)
+        return d if math.isfinite(d) else None
+    if isinstance(value, str):
+        num = _try_parse_float(value.strip())
+        return num if num is not None and math.isfinite(num) else None
+    return None
+
+
+def _float_to_text(d: float) -> str:
+    """JS ``String(number)`` / C# ``"R"`` semantics: integral floats drop the
+    trailing ``.0`` (EavExtraction.cs:790)."""
+    if math.isnan(d):
+        return "NaN"
+    if math.isinf(d):
+        return "Infinity" if d > 0 else "-Infinity"
+    if d.is_integer() and abs(d) < 1e16:
+        return str(int(d))
+    return repr(d)
+
+
+def _to_text(value: Any) -> str:
+    """Port of ToTextNative (EavExtraction.cs:785-795): lowercase booleans,
+    strings verbatim, invariant numbers."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, float):
+        return _float_to_text(value)
+    if isinstance(value, int):
+        return str(value)
+    return str(value)
+
+
+def _make_row(
+    object_id: str,
+    path: str,
+    value: Any,
+    units: str | None,
+    internal_definition_name: str | None,
+) -> EavRow:
+    """Port of MakeRowNative (EavExtraction.cs:778-783)."""
+    inferred = _infer_type(value)
+    value_num = _to_num(value) if inferred == "number" else None
+    return EavRow(
+        object_id,
+        path,
+        _to_text(value),
+        value_num,
+        inferred,
+        units,
+        internal_definition_name,
+    )
+
+
+def _finite_number(token: Any) -> float | None:
+    """Port of TryGetFiniteNumber (EavExtraction.cs:555-568): int/float only
+    (booleans excluded), finite."""
+    if isinstance(token, bool):
+        return None
+    if isinstance(token, int | float):
+        d = float(token)
+        return d if math.isfinite(d) else None
+    return None
+
+
+# ───────────────────────────── core walk ───────────────────────────────────
+
+
+def _str_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _ref_id(entry: Mapping[str, Any]) -> str | None:
+    """``referencedId`` (if a string) else ``id`` (if a string), matching the C#
+    ``Type == String`` checks — an empty-string ``referencedId`` still wins."""
+    rid = entry.get("referencedId")
+    if isinstance(rid, str):
+        return rid
+    eid = entry.get("id")
+    return eid if isinstance(eid, str) else None
+
+
+def _walk_properties(
+    object_id: str,
+    obj: Mapping[str, Any],
+    prefix: str,
+    depth: int,
+    rows: list[EavRow],
+    excluded: frozenset[str] | set[str] | None,
+) -> None:
+    """Port of WalkPropertiesNative (EavExtraction.cs:666-732). Exclusions apply
+    at depth 0 only; recursion drops them."""
+    if depth >= MAX_DEPTH:
+        return
+
+    for key, val in obj.items():
+        if depth == 0 and excluded and key in excluded:
+            continue
+        if val is None:
+            continue
+
+        path = f"{prefix}.{key}"
+
+        if isinstance(val, dict):
+            # Parameter pattern { name, value } → single row at this path.
+            if "name" in val and "value" in val:
+                param_val = val.get("value")
+                if not _is_scalar(param_val):
+                    continue
+                rows.append(
+                    _make_row(
+                        object_id,
+                        path,
+                        param_val,
+                        _str_or_none(val.get("units")),
+                        _str_or_none(val.get("internalDefinitionName")),
+                    )
+                )
+                continue
+
+            # Parity with the JObject walk's special-cases.
+            if key == "Structure" and prefix.endswith(".Type Parameters"):
+                continue
+            if key == "Material Quantities":
+                continue  # handled separately
+
+            _walk_properties(object_id, val, path, depth + 1, rows, None)
+            continue
+
+        if _is_scalar(val):
+            rows.append(_make_row(object_id, path, val, None, None))
+        # non-scalar, non-dict (lists/arrays, etc.) → skipped, as in C#.
+
+
+def _extract_material_quantities(
+    object_id: str, mat_quants: Mapping[str, Any], rows: list[EavRow]
+) -> None:
+    """Port of ExtractMaterialQuantitiesNative (EavExtraction.cs:734-750)."""
+    for mat_name, mat in mat_quants.items():
+        if not isinstance(mat, dict):
+            continue
+        category = _str_or_none(mat.get("materialCategory")) or "Unknown"
+        _append_quantity(object_id, mat, "area", category, mat_name, rows)
+        _append_quantity(object_id, mat, "volume", category, mat_name, rows)
+
+
+def _append_quantity(
+    object_id: str,
+    mat: Mapping[str, Any],
+    kind: str,
+    category: str,
+    mat_name: str,
+    rows: list[EavRow],
+) -> None:
+    """Port of AppendQuantityNative (EavExtraction.cs:752-773)."""
+    q = mat.get(kind)
+    if not isinstance(q, dict):
+        return
+    value = q.get("value")
+    if not _is_scalar(value):
+        return
+    rows.append(
+        _make_row(
+            object_id,
+            f"properties.Material Quantities.{category}.{mat_name}.{kind}",
+            value,
+            _str_or_none(q.get("units")),
+            None,
+        )
+    )
+
+
+# ───────────────────────────── public API ──────────────────────────────────
+
+
+def flatten_properties(
+    application_id: str,
+    properties: Mapping[str, Any],
+    root_scalars: Mapping[str, Any] | Iterable[tuple[str, Any]] | None = None,
+    excluded_top_level: frozenset[str] | set[str] | None = None,
+) -> list[EavRow]:
+    """Flatten an object's native property tree to EAV rows.
+
+    Port of FlattenProperties (EavExtraction.cs:585-613). ``root_scalars`` are
+    bare top-level fields emitted under their plain key; ``properties`` is walked
+    under the ``properties.`` prefix; Revit ``Material Quantities`` is extracted
+    with its special structure.
+
+    Args:
+        application_id: the object id every emitted row is keyed by.
+        properties: the nested ``properties`` dict to walk.
+        root_scalars: optional mapping or iterable of ``(key, value)`` pairs;
+            only scalar values are emitted (one row each).
+        excluded_top_level: top-level keys under ``properties`` to skip wholesale
+            (the entire subtree is dropped). ``None`` extracts everything.
+    """
+    rows: list[EavRow] = []
+
+    if root_scalars is not None:
+        items = (
+            root_scalars.items() if isinstance(root_scalars, Mapping) else root_scalars
+        )
+        for key, value in items:
+            if _is_scalar(value):
+                rows.append(_make_row(application_id, key, value, None, None))
+
+    _walk_properties(
+        application_id, properties, "properties", 0, rows, excluded_top_level
+    )
+
+    mq = properties.get("Material Quantities")
+    if isinstance(mq, dict):
+        _extract_material_quantities(application_id, mq, rows)
+
+    return rows
+
+
+def flatten_subtree(subtree: Mapping[str, Any], path_prefix: str) -> list[EavRow]:
+    """Flatten a property SUBTREE under ``path_prefix`` — used to route Type/
+    System parameter trees into ``type_eav``. Rows carry an empty object id (the
+    caller keys them by ``type_index``). Port of FlattenSubtree
+    (EavExtraction.cs:621-625)."""
+    rows: list[EavRow] = []
+    _walk_properties("", subtree, path_prefix, 0, rows, None)
+    return rows
+
+
+def flatten_object_properties(
+    object_id: str,
+    obj: Mapping[str, Any],
+    excluded: frozenset[str] | set[str] | None = None,
+) -> list[EavRow]:
+    """Dispatch on ``speckle_type`` and extract EAV rows for a whole parsed
+    object. Port of FlattenObjectProperties (EavExtraction.cs:110-131):
+    InstanceProxy → root scalars + transform; DataObject (or missing type) →
+    full extraction; Collection/Layer → root scalars + properties + elements;
+    everything else → no rows."""
+    speckle_type = _str_or_none(obj.get("speckle_type")) or ""
+
+    if "InstanceProxy" in speckle_type:
+        return _extract_instance_proxy(object_id, obj)
+    if speckle_type == "" or speckle_type.startswith("Objects.Data."):
+        return _extract_data_object(object_id, obj, excluded)
+    if _is_collection_type(speckle_type):
+        return _extract_collection(object_id, obj, excluded)
+    return []
+
+
+def produces_rows(speckle_type: str) -> bool:
+    """Cheap pre-check matching the dispatch in :func:`flatten_object_properties`
+    (EavExtraction.cs:138-142)."""
+    return (
+        speckle_type == ""
+        or "InstanceProxy" in speckle_type
+        or speckle_type.startswith("Objects.Data.")
+        or _is_collection_type(speckle_type)
+    )
+
+
+def _is_collection_type(speckle_type: str) -> bool:
+    """Port of IsCollectionType (EavExtraction.cs:144-151)."""
+    return speckle_type.endswith(".Layer") or "Collection" in speckle_type
+
+
+def _extract_root_scalars(
+    object_id: str, obj: Mapping[str, Any], rows: list[EavRow]
+) -> None:
+    """Port of ExtractRootScalars (EavExtraction.cs:253-268)."""
+    for field in ROOT_SCALAR_FIELDS:
+        val = obj.get(field)
+        if val is None:
+            continue
+        if isinstance(val, dict | list):
+            continue
+        if _is_scalar(val):
+            rows.append(_make_row(object_id, field, val, None, None))
+
+
+def _extract_data_object(
+    object_id: str,
+    obj: Mapping[str, Any],
+    excluded: frozenset[str] | set[str] | None,
+) -> list[EavRow]:
+    """Port of ExtractDataObject (EavExtraction.cs:153-196)."""
+    rows: list[EavRow] = []
+    _extract_root_scalars(object_id, obj, rows)
+
+    props = obj.get("properties")
+    if isinstance(props, dict):
+        _walk_properties(object_id, props, "properties", 0, rows, excluded)
+        mq = props.get("Material Quantities")
+        if isinstance(mq, dict):
+            _extract_material_quantities(object_id, mq, rows)
+
+    loc = obj.get("location")
+    if isinstance(loc, dict):
+        _extract_location(object_id, loc, rows)
+
+    dv = obj.get("displayValue")
+    if isinstance(dv, list):
+        _extract_display_value_refs(object_id, dv, rows)
+
+    elements = obj.get("elements")
+    if isinstance(elements, list):
+        _extract_elements_refs(object_id, elements, rows)
+
+    return rows
+
+
+def _extract_instance_proxy(object_id: str, obj: Mapping[str, Any]) -> list[EavRow]:
+    """Port of ExtractInstanceProxy (EavExtraction.cs:198-227)."""
+    rows: list[EavRow] = []
+    _extract_root_scalars(object_id, obj, rows)
+
+    units = _str_or_none(obj.get("units"))
+    transform = obj.get("transform")
+    if isinstance(transform, list) and len(transform) == 16:
+        for idx, suffix in ((3, "tx"), (7, "ty"), (11, "tz")):
+            v = _finite_number(transform[idx])
+            if v is not None:
+                rows.append(
+                    _make_row(object_id, f"proxy.transform.{suffix}", v, units, None)
+                )
+        rows.append(
+            _make_row(
+                object_id,
+                "proxy.transform.matrix",
+                json.dumps(transform, separators=(",", ":")),
+                units,
+                None,
+            )
+        )
+
+    return rows
+
+
+def _extract_collection(
+    object_id: str,
+    obj: Mapping[str, Any],
+    excluded: frozenset[str] | set[str] | None,
+) -> list[EavRow]:
+    """Port of ExtractCollection (EavExtraction.cs:229-251)."""
+    rows: list[EavRow] = []
+    _extract_root_scalars(object_id, obj, rows)
+
+    props = obj.get("properties")
+    if isinstance(props, dict):
+        _walk_properties(object_id, props, "properties", 0, rows, excluded)
+
+    elements = obj.get("elements")
+    if isinstance(elements, list):
+        _extract_elements_refs(object_id, elements, rows)
+
+    return rows
+
+
+def _extract_location(
+    object_id: str, loc: Mapping[str, Any], rows: list[EavRow]
+) -> None:
+    """Port of ExtractLocation (EavExtraction.cs:270-280)."""
+    units = _str_or_none(loc.get("units"))
+    for axis in ("x", "y", "z"):
+        v = _finite_number(loc.get(axis))
+        if v is not None:
+            rows.append(_make_row(object_id, f"location.{axis}", v, units, None))
+
+
+def _extract_display_value_refs(
+    object_id: str, dv: list[Any], rows: list[EavRow]
+) -> None:
+    """Port of ExtractDisplayValueRefs (EavExtraction.cs:282-306)."""
+    for i, entry in enumerate(dv):
+        if not isinstance(entry, dict):
+            continue
+        ref_id = _ref_id(entry)
+        if ref_id is not None:
+            rows.append(
+                _make_row(
+                    object_id, f"displayValue.{i}.referencedId", ref_id, None, None
+                )
+            )
+
+
+def _extract_elements_refs(
+    object_id: str, elements: list[Any], rows: list[EavRow]
+) -> None:
+    """Port of ExtractElementsRefs (EavExtraction.cs:308-332). All child refs are
+    serialised into a single JSON array stored in ``value_text``."""
+    ref_ids: list[str] = []
+    for entry in elements:
+        if not isinstance(entry, dict):
+            continue
+        ref_id = _ref_id(entry)
+        if ref_id is not None:
+            ref_ids.append(ref_id)
+    if not ref_ids:
+        return
+    rows.append(
+        _make_row(
+            object_id,
+            "elements",
+            json.dumps(ref_ids, separators=(",", ":")),
+            None,
+            None,
+        )
+    )

--- a/src/specklepy/bundle/eav_writer.py
+++ b/src/specklepy/bundle/eav_writer.py
@@ -3,15 +3,16 @@
 Port of the .NET ``EavWriter``. Passive columnar files, no WAL/checkpoint/index::
 
   {base}.eav.objects.parquet(object_index, application_id)      -- the K dictionary
-  {base}.eav.paths.parquet(path_index, path)                    -- shared path vocabulary
+  {base}.eav.paths.parquet(path_index, path)                    -- shared path vocab
   {base}.eav.eav.parquet(object_index, path_index, value_*)     -- INSTANCE-scoped rows
   {base}.eav.types.parquet(type_index, type_key)                -- type dictionary
-  {base}.eav.type_eav.parquet(type_index, path_index, value_*)  -- TYPE-scoped, once per type
+  {base}.eav.type_eav.parquet(type_index, path_index, value_*)  -- TYPE rows, per type
   {base}.eav.object_type.parquet(object_index, type_index)      -- the weak ref
 
-No manifest is written: consumers build their own ``read_parquet`` views (the read recipe
-lives in notes/topology-envelope-SOT.md §4/§6). Interning (applicationId/path/type_key ->
-dense int) and type dedup are unchanged. Not thread-safe: calls are sequential.
+No manifest is written: consumers build their own ``read_parquet`` views (the read
+recipe lives in notes/topology-envelope-SOT.md §4/§6). Interning
+(applicationId/path/type_key -> dense int) and type dedup are unchanged. Not
+thread-safe: calls are sequential.
 """
 
 from __future__ import annotations
@@ -62,7 +63,8 @@ class EavWriter:
             self._p("object_type.parquet"), schema_of(BY_TABLE["object_type"])
         )
 
-        # interning: applicationId / path / type_key -> dense sequential int (first-seen order).
+        # interning: applicationId / path / type_key -> dense sequential int
+        # (first-seen order).
         self._object_index: dict[str, int] = {}
         self._path_index: dict[str, int] = {}
         self._type_index: dict[str, int] = {}
@@ -70,11 +72,13 @@ class EavWriter:
 
     @property
     def eav_db_path(self) -> str:
-        """The directory holding this artefact's parquet tables (no single entry file)."""
+        """The directory holding this artefact's parquet tables (no single entry
+        file)."""
         return self.output_dir
 
     def get_or_add_object(self, application_id: str) -> int:
-        """Intern ``application_id`` to its dense object_index, writing the dict row on first sight.
+        """Intern ``application_id`` to its dense object_index, writing the dict row
+        on first sight.
 
         Public so the envelope path resolves the SAME K for an object's edges.
         """
@@ -107,7 +111,8 @@ class EavWriter:
         type_key: str,
         type_rows_factory: Callable[[], Iterable[EavRow]],
     ) -> None:
-        """Link an object to its type via ``object_type`` and write the type's params ONCE.
+        """Link an object to its type via ``object_type`` and write the type's params
+        ONCE.
 
         ``type_rows_factory`` is invoked only on the type's first sight (dedup).
         """

--- a/src/specklepy/bundle/eav_writer.py
+++ b/src/specklepy/bundle/eav_writer.py
@@ -1,0 +1,166 @@
+"""Compact, interned EAV writer — direct Zstd parquet, one file per table.
+
+Port of the .NET ``EavWriter``. Passive columnar files, no WAL/checkpoint/index::
+
+  {base}.eav.objects.parquet(object_index, application_id)      -- the K dictionary
+  {base}.eav.paths.parquet(path_index, path)                    -- shared path vocabulary
+  {base}.eav.eav.parquet(object_index, path_index, value_*)     -- INSTANCE-scoped rows
+  {base}.eav.types.parquet(type_index, type_key)                -- type dictionary
+  {base}.eav.type_eav.parquet(type_index, path_index, value_*)  -- TYPE-scoped, once per type
+  {base}.eav.object_type.parquet(object_index, type_index)      -- the weak ref
+
+No manifest is written: consumers build their own ``read_parquet`` views (the read recipe
+lives in notes/topology-envelope-SOT.md §4/§6). Interning (applicationId/path/type_key ->
+dense int) and type dedup are unchanged. Not thread-safe: calls are sequential.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Iterable
+
+from specklepy.bundle.eav_extraction import EavRow
+from specklepy.bundle.parquet_table_writer import ParquetTableWriter, schema_of
+from specklepy.bundle.spec import BY_TABLE
+
+
+def _value_boolean(row: EavRow) -> bool | None:
+    if row.type != "boolean":
+        return None
+    if isinstance(row.value_text, bool):
+        return row.value_text
+    lowered = (row.value_text or "").strip().lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    return None
+
+
+class EavWriter:
+    def __init__(self, output_dir: str, base_name: str) -> None:
+        os.makedirs(output_dir, exist_ok=True)
+        self.output_dir = output_dir
+        self.base_name = base_name
+
+        self._objects = ParquetTableWriter(
+            self._p("objects.parquet"), schema_of(BY_TABLE["objects"])
+        )
+        self._paths = ParquetTableWriter(
+            self._p("paths.parquet"), schema_of(BY_TABLE["paths"])
+        )
+        self._eav = ParquetTableWriter(
+            self._p("eav.parquet"), schema_of(BY_TABLE["eav"])
+        )
+        self._types = ParquetTableWriter(
+            self._p("types.parquet"), schema_of(BY_TABLE["types"])
+        )
+        self._type_eav = ParquetTableWriter(
+            self._p("type_eav.parquet"), schema_of(BY_TABLE["type_eav"])
+        )
+        self._object_type = ParquetTableWriter(
+            self._p("object_type.parquet"), schema_of(BY_TABLE["object_type"])
+        )
+
+        # interning: applicationId / path / type_key -> dense sequential int (first-seen order).
+        self._object_index: dict[str, int] = {}
+        self._path_index: dict[str, int] = {}
+        self._type_index: dict[str, int] = {}
+        self._completed = False
+
+    @property
+    def eav_db_path(self) -> str:
+        """The directory holding this artefact's parquet tables (no single entry file)."""
+        return self.output_dir
+
+    def get_or_add_object(self, application_id: str) -> int:
+        """Intern ``application_id`` to its dense object_index, writing the dict row on first sight.
+
+        Public so the envelope path resolves the SAME K for an object's edges.
+        """
+        idx = self._object_index.get(application_id)
+        if idx is not None:
+            return idx
+        idx = len(self._object_index)
+        self._object_index[application_id] = idx
+        self._objects.add_row(idx, application_id)
+        return idx
+
+    def add_rows(self, application_id: str, rows: Iterable[EavRow]) -> None:
+        """Append the flattened rows for one object, keyed by its ``application_id``."""
+        self._ensure_not_completed()
+        object_index = self.get_or_add_object(application_id)
+        for row in rows:
+            self._eav.add_row(
+                object_index,
+                self._get_or_add_path(row.path),
+                row.value_text,
+                row.value_num,
+                _value_boolean(row),
+                row.units,
+                row.internal_definition_name,
+            )
+
+    def add_type(
+        self,
+        application_id: str,
+        type_key: str,
+        type_rows_factory: Callable[[], Iterable[EavRow]],
+    ) -> None:
+        """Link an object to its type via ``object_type`` and write the type's params ONCE.
+
+        ``type_rows_factory`` is invoked only on the type's first sight (dedup).
+        """
+        self._ensure_not_completed()
+        type_index, is_new = self._get_or_add_type(type_key)
+        if is_new:
+            for row in type_rows_factory():
+                self._type_eav.add_row(
+                    type_index,
+                    self._get_or_add_path(row.path),
+                    row.value_text,
+                    row.value_num,
+                    _value_boolean(row),
+                    row.units,
+                    row.internal_definition_name,
+                )
+        self._object_type.add_row(self.get_or_add_object(application_id), type_index)
+
+    def complete(self) -> None:
+        if self._completed:
+            return
+        self._completed = True
+        for w in (
+            self._objects,
+            self._paths,
+            self._eav,
+            self._types,
+            self._type_eav,
+            self._object_type,
+        ):
+            w.complete()
+
+    def _get_or_add_path(self, path: str) -> int:
+        idx = self._path_index.get(path)
+        if idx is not None:
+            return idx
+        idx = len(self._path_index)
+        self._path_index[path] = idx
+        self._paths.add_row(idx, path)
+        return idx
+
+    def _get_or_add_type(self, type_key: str) -> tuple[int, bool]:
+        idx = self._type_index.get(type_key)
+        if idx is not None:
+            return idx, False
+        idx = len(self._type_index)
+        self._type_index[type_key] = idx
+        self._types.add_row(idx, type_key)
+        return idx, True
+
+    def _p(self, suffix: str) -> str:
+        return os.path.join(self.output_dir, f"{self.base_name}.eav.{suffix}")
+
+    def _ensure_not_completed(self) -> None:
+        if self._completed:
+            raise RuntimeError("Writer already completed.")

--- a/src/specklepy/bundle/envelope_writer.py
+++ b/src/specklepy/bundle/envelope_writer.py
@@ -4,12 +4,12 @@ Port of the .NET ``EnvelopeWriter``. The table SHAPES and the self-describing ca
 (rel_types / node_kinds / meta) come from the generated ``speckle-bundle-spec`` — this
 writer never hand-declares them. ::
 
-  {base}.envelope.relations.parquet(rel, src, dst, ord)   -- typed edges; ns fixed by rel
+  {base}.envelope.relations.parquet(rel, src, dst, ord)  -- typed edges; ns per rel
   {base}.envelope.nodes.parquet(id, kind, name, def_ref,  -- shared value-entities;
-        transform, units, subtype, argb, opacity,            `subtype` is the CONTAINER
-        metalness, roughness, elevation)                     discriminator (Model/Collection/…)
-  {base}.envelope.{meta,rel_types,node_kinds}.parquet     -- self-describing catalog
-  {base}.envelope.scene_views.parquet(...)                -- producer-authored grouping; absent if none
+        transform, units, subtype, argb, opacity,         -- `subtype` is the CONTAINER
+        metalness, roughness, elevation)                  -- discriminator (Model/Coll)
+  {base}.envelope.{meta,rel_types,node_kinds}.parquet    -- self-describing catalog
+  {base}.envelope.scene_views.parquet(...)               -- producer grouping; omit if 0
 
 ``transform`` is 16 row-major doubles, comma-separated. Not thread-safe.
 """
@@ -42,7 +42,8 @@ class ProjectionSource(IntEnum):
 class SceneViewKey:
     """One ordered key of a SceneView projection.
 
-    For ``REL``, ``ref`` is a rel id as a string; for ``EAV`` it is a bare eav attr key.
+    For ``REL``, ``ref`` is a rel id as a string; for ``EAV`` it is a bare eav attr
+    key.
     Build via :meth:`rel` / :meth:`eav` so ``ref`` is encoded correctly.
     """
 
@@ -62,8 +63,8 @@ class SceneViewKey:
 class SceneView:
     """A producer-authored scene-explorer projection (SOT §8).
 
-    Exactly one view per artefact should be ``is_default``; ``keys`` are outermost-first.
-    Producers OMIT keys with no data.
+    Exactly one view per artefact should be ``is_default``; ``keys`` are
+    outermost-first. Producers OMIT keys with no data.
     """
 
     view: int
@@ -94,7 +95,8 @@ class EnvelopeWriter:
         return self.output_dir
 
     def add_relation(self, rel: int, src: int, dst: int, ord: int) -> None:
-        """Append one typed edge. ``src``/``dst`` are dense ids in the namespaces fixed by ``rel``."""
+        """Append one typed edge. ``src``/``dst`` are dense ids in the namespaces
+        fixed by ``rel``."""
         self._ensure_not_completed()
         self._relations.add_row(int(rel), src, dst, ord)
 
@@ -131,7 +133,8 @@ class EnvelopeWriter:
         )
 
     def add_scene_view(self, view: SceneView) -> None:
-        """Buffer a producer-authored projection; flushed to scene_views.parquet on complete()."""
+        """Buffer a producer-authored projection; flushed to scene_views.parquet on
+        complete()."""
         self._ensure_not_completed()
         self._scene_views.append(view)
 
@@ -143,8 +146,9 @@ class EnvelopeWriter:
         self._nodes.complete()
         self._write_scene_views()
 
-    # Self-describing catalog (SOT §6): rel/kind vocabulary + schema version, from the generated
-    # spec catalog (live + reserved rows; retired ids are absent and never reused). Tiny.
+    # Self-describing catalog (SOT §6): rel/kind vocabulary + schema version, from the
+    # generated spec catalog (live + reserved rows; retired ids are absent and never
+    # reused). Tiny.
     def _write_catalog(self) -> None:
         with ParquetTableWriter(
             self._p("meta.parquet"),

--- a/src/specklepy/bundle/envelope_writer.py
+++ b/src/specklepy/bundle/envelope_writer.py
@@ -1,0 +1,212 @@
+"""Envelope topology writer — direct Zstd parquet, one file per table.
+
+Port of the .NET ``EnvelopeWriter``. The table SHAPES and the self-describing catalog
+(rel_types / node_kinds / meta) come from the generated ``speckle-bundle-spec`` — this
+writer never hand-declares them. ::
+
+  {base}.envelope.relations.parquet(rel, src, dst, ord)   -- typed edges; ns fixed by rel
+  {base}.envelope.nodes.parquet(id, kind, name, def_ref,  -- shared value-entities;
+        transform, units, subtype, argb, opacity,            `subtype` is the CONTAINER
+        metalness, roughness, elevation)                     discriminator (Model/Collection/…)
+  {base}.envelope.{meta,rel_types,node_kinds}.parquet     -- self-describing catalog
+  {base}.envelope.scene_views.parquet(...)                -- producer-authored grouping; absent if none
+
+``transform`` is 16 row-major doubles, comma-separated. Not thread-safe.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import IntEnum
+
+import pyarrow as pa
+
+from specklepy.bundle.parquet_table_writer import ParquetTableWriter, schema_of
+from specklepy.bundle.spec import (
+    BY_TABLE,
+    NODE_KINDS,
+    REL_TYPES,
+    SCHEMA_VERSION,
+)
+
+
+class ProjectionSource(IntEnum):
+    """The store a SceneViewKey reads from: a relation walk or an eav group-by."""
+
+    REL = 0
+    EAV = 1
+
+
+@dataclass(frozen=True)
+class SceneViewKey:
+    """One ordered key of a SceneView projection.
+
+    For ``REL``, ``ref`` is a rel id as a string; for ``EAV`` it is a bare eav attr key.
+    Build via :meth:`rel` / :meth:`eav` so ``ref`` is encoded correctly.
+    """
+
+    source: ProjectionSource
+    ref: str
+
+    @staticmethod
+    def rel(rel: int) -> SceneViewKey:
+        return SceneViewKey(ProjectionSource.REL, str(int(rel)))
+
+    @staticmethod
+    def eav(attr_key: str) -> SceneViewKey:
+        return SceneViewKey(ProjectionSource.EAV, attr_key)
+
+
+@dataclass(frozen=True)
+class SceneView:
+    """A producer-authored scene-explorer projection (SOT §8).
+
+    Exactly one view per artefact should be ``is_default``; ``keys`` are outermost-first.
+    Producers OMIT keys with no data.
+    """
+
+    view: int
+    name: str
+    is_default: bool
+    keys: list[SceneViewKey]
+
+
+class EnvelopeWriter:
+    def __init__(self, output_dir: str, base_name: str) -> None:
+        os.makedirs(output_dir, exist_ok=True)
+        self.output_dir = output_dir
+        self.base_name = base_name
+
+        self._relations = ParquetTableWriter(
+            self._p("relations.parquet"), schema_of(BY_TABLE["relations"])
+        )
+        self._nodes = ParquetTableWriter(
+            self._p("nodes.parquet"), schema_of(BY_TABLE["nodes"])
+        )
+        self._scene_views: list[SceneView] = []
+        self._completed = False
+
+        self._write_catalog()
+
+    @property
+    def envelope_db_path(self) -> str:
+        return self.output_dir
+
+    def add_relation(self, rel: int, src: int, dst: int, ord: int) -> None:
+        """Append one typed edge. ``src``/``dst`` are dense ids in the namespaces fixed by ``rel``."""
+        self._ensure_not_completed()
+        self._relations.add_row(int(rel), src, dst, ord)
+
+    def add_node(
+        self,
+        id: int,
+        kind: int,
+        name: str | None,
+        def_ref: int | None,
+        transform: str | None,
+        units: str | None,
+        subtype: str | None,
+        argb: int | None,
+        opacity: float | None,
+        metalness: float | None,
+        roughness: float | None,
+        elevation: float | None,
+    ) -> None:
+        """Append one value-node. Only the columns relevant to ``kind`` are non-null."""
+        self._ensure_not_completed()
+        self._nodes.add_row(
+            id,
+            int(kind),
+            name,
+            def_ref,
+            transform,
+            units,
+            subtype,
+            argb,
+            opacity,
+            metalness,
+            roughness,
+            elevation,
+        )
+
+    def add_scene_view(self, view: SceneView) -> None:
+        """Buffer a producer-authored projection; flushed to scene_views.parquet on complete()."""
+        self._ensure_not_completed()
+        self._scene_views.append(view)
+
+    def complete(self) -> None:
+        if self._completed:
+            return
+        self._completed = True
+        self._relations.complete()
+        self._nodes.complete()
+        self._write_scene_views()
+
+    # Self-describing catalog (SOT §6): rel/kind vocabulary + schema version, from the generated
+    # spec catalog (live + reserved rows; retired ids are absent and never reused). Tiny.
+    def _write_catalog(self) -> None:
+        with ParquetTableWriter(
+            self._p("meta.parquet"),
+            pa.schema(
+                [
+                    pa.field("schema_version", pa.int32(), nullable=False),
+                    pa.field("produced_by", pa.string()),
+                ]
+            ),
+        ) as meta:
+            meta.add_row(SCHEMA_VERSION, "specklepy EnvelopeWriter")
+
+        with ParquetTableWriter(
+            self._p("rel_types.parquet"),
+            pa.schema(
+                [
+                    pa.field("rel", pa.int32(), nullable=False),
+                    pa.field("name", pa.string()),
+                    pa.field("src_ns", pa.string()),
+                    pa.field("dst_ns", pa.string()),
+                ]
+            ),
+        ) as rt:
+            for r in REL_TYPES:
+                if r.status == "retired":
+                    continue
+                rt.add_row(r.id, r.name, r.src_ns, r.dst_ns)
+
+        with ParquetTableWriter(
+            self._p("node_kinds.parquet"),
+            pa.schema(
+                [
+                    pa.field("kind", pa.int32(), nullable=False),
+                    pa.field("name", pa.string()),
+                ]
+            ),
+        ) as nk:
+            for k in NODE_KINDS:
+                if k.status == "retired":
+                    continue
+                nk.add_row(k.id, k.name)
+
+    def _write_scene_views(self) -> None:
+        if not self._scene_views:
+            return
+        with ParquetTableWriter(
+            self._p("scene_views.parquet"), schema_of(BY_TABLE["scene_views"])
+        ) as sv:
+            for v in self._scene_views:
+                for ord, key in enumerate(v.keys):
+                    sv.add_row(
+                        v.view,
+                        v.name,
+                        v.is_default,
+                        ord,
+                        "rel" if key.source == ProjectionSource.REL else "eav",
+                        key.ref,
+                    )
+
+    def _p(self, suffix: str) -> str:
+        return os.path.join(self.output_dir, f"{self.base_name}.envelope.{suffix}")
+
+    def _ensure_not_completed(self) -> None:
+        if self._completed:
+            raise RuntimeError("Writer already completed.")

--- a/src/specklepy/bundle/geometries_writer.py
+++ b/src/specklepy/bundle/geometries_writer.py
@@ -1,0 +1,216 @@
+"""Writes ``geometries.parquet`` — one row per geometry: (geometryIndex, content, id, type).
+
+Port of the .NET ``GeometriesParquetWriter``. ``geometryIndex`` is the dense geometry-K
+the envelope's DISPLAY/DEFINES/HAS_MATERIAL edges reference (pure int, no applicationId
+strings). ``id`` is the SHA256 of the blob, kept as a column for READ-TIME shape dedup
+(the consumer collapses identical shapes into one GPU buffer); we do NOT content-dedup at
+write time, so every per-mesh row stays addressable and its material bindable.
+
+Sharded: shard 0 keeps the canonical ``{base}.geometries.parquet`` name (a model that fits
+in one shard is byte-for-byte unchanged); overflow shards are ``{base}.geometries.{N}.parquet``
+(N=1,2,…). Consumers read the set via the glob ``{base}.geometries*.parquet``. The cap is on
+UNCOMPRESSED content bytes, so the on-disk (Zstd) shard is always smaller than the cap — this
+contract is shared verbatim with the native nwextract ``GeomSharder`` (C++).
+"""
+
+from __future__ import annotations
+
+import glob
+import hashlib
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from specklepy.bundle.parquet_table_writer import schema_of
+from specklepy.bundle.spec import BY_TABLE
+
+# Flush (write a row group + free the buffer) once buffered blob bytes reach this budget.
+_DEFAULT_ROWGROUP_MB = 64
+_MAX_ROWS_PER_GROUP = 200_000  # safety cap for tiny-blob models
+# Roll to a new shard once the current shard's uncompressed content bytes would exceed this.
+_DEFAULT_SHARD_MB = 1536  # 1.5 GiB uncompressed content per shard
+
+_SGEO_HEADER_SIZE = 16
+_SGEO_MAGIC = b"SGEO"
+
+# SGEO primitive_type byte (header offset 0x05) -> geometries.type label.
+_PRIMITIVE_TYPE_NAME = {
+    0: "mesh",
+    1: "line",
+    2: "polyline",
+    3: "polycurve",
+    4: "curve",
+    5: "arc",
+    6: "circle",
+    7: "points",
+    8: "ellipse",
+    9: "spiral",
+    10: "box",
+}
+
+
+def _mb_env(name: str, fallback: int) -> int:
+    raw = os.environ.get(name)
+    try:
+        v = int(raw) if raw is not None else 0
+    except ValueError:
+        v = 0
+    return v if v > 0 else fallback
+
+
+class GeometriesParquetWriter:
+    def __init__(
+        self, output_dir: str, base_name: str, shard_cap_bytes: int | None = None
+    ) -> None:
+        os.makedirs(output_dir, exist_ok=True)
+        self._output_dir = output_dir
+        self._base_name = base_name
+        self._schema = schema_of(BY_TABLE["geometries"])
+        self._flush_bytes = (
+            _mb_env("SPECKLE_PARQUET_ROWGROUP_MB", _DEFAULT_ROWGROUP_MB) * 1024 * 1024
+        )
+        self._shard_cap_bytes = (
+            shard_cap_bytes
+            if shard_cap_bytes is not None
+            else _mb_env("SPECKLE_GEOMETRY_SHARD_MB", _DEFAULT_SHARD_MB) * 1024 * 1024
+        )
+
+        self._seen: set[int] = set()
+        self._geometry_paths: list[str] = []
+        self._shard_index = 0
+        self._shard_bytes = (
+            0  # uncompressed content bytes assigned to the current shard
+        )
+        self._completed = False
+
+        # in-flight row-group buffers (parallel lists, one entry per row).
+        self._indices: list[int] = []
+        self._contents: list[bytes] = []
+        self._ids: list[str] = []
+        self._types: list[str] = []
+        self._buffered_bytes = 0
+
+        self.geometries_path = self._shard_path(0)
+        # a previous run may have produced MORE shards than this one will — clear the whole set.
+        self._delete_stale_shards()
+        self._open_shard(0)
+
+    @property
+    def geometry_paths(self) -> list[str]:
+        """Every geometry shard file written, in order (shard 0 = ``geometries_path``)."""
+        return list(self._geometry_paths)
+
+    def add_geometry(self, geometry_index: int, sgeo: bytes) -> None:
+        """Add one SGEO geometry buffer under its dense ``geometry_index``.
+
+        ``id`` is the SHA256 of the blob; ``type`` is read from the SGEO header.
+        """
+        if len(sgeo) < _SGEO_HEADER_SIZE or sgeo[0:4] != _SGEO_MAGIC:
+            raise ValueError("Buffer is not a valid SGEO blob.")
+        self._add_row(
+            geometry_index, sgeo, _PRIMITIVE_TYPE_NAME.get(sgeo[5], "unknown")
+        )
+
+    def add_raw_geometry(
+        self, geometry_index: int, content: bytes, type_label: str
+    ) -> None:
+        """Add one RAW (non-SGEO) blob verbatim with an explicit ``type`` label (e.g. "3dm")."""
+        self._add_row(geometry_index, content, type_label)
+
+    def complete(self) -> None:
+        if self._completed:
+            return
+        self._completed = True
+        self._flush_row_group()
+        self._finalize_current_shard()
+
+    def __enter__(self) -> GeometriesParquetWriter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.complete()
+
+    # ── internals ──────────────────────────────────────────────────────────
+
+    def _shard_path(self, shard_index: int) -> str:
+        name = (
+            f"{self._base_name}.geometries.parquet"
+            if shard_index == 0
+            else f"{self._base_name}.geometries.{shard_index}.parquet"
+        )
+        return os.path.join(self._output_dir, name)
+
+    def _open_shard(self, shard_index: int) -> None:
+        path = self._shard_path(shard_index)
+        self._writer = pq.ParquetWriter(path, self._schema, compression="zstd")
+        self._shard_bytes = 0
+        self._geometry_paths.append(path)
+
+    def _finalize_current_shard(self) -> None:
+        self._writer.close()
+
+    def _roll_shard(self) -> None:
+        self._flush_row_group()
+        self._finalize_current_shard()
+        self._shard_index += 1
+        self._open_shard(self._shard_index)
+
+    def _delete_stale_shards(self) -> None:
+        for stale in [
+            self._shard_path(0),
+            *glob.glob(
+                self._shard_path(0).replace(
+                    ".geometries.parquet", ".geometries.*.parquet"
+                )
+            ),
+        ]:
+            if os.path.exists(stale):
+                os.remove(stale)
+
+    def _add_row(self, geometry_index: int, content: bytes, type_label: str) -> None:
+        if self._completed:
+            raise RuntimeError("Writer already completed.")
+        if geometry_index in self._seen:
+            return
+        self._seen.add(geometry_index)
+
+        # Roll before this blob would push the current shard past the cap. Guard on
+        # _shard_bytes > 0 so a single over-cap blob still lands in its own shard.
+        if (
+            self._shard_bytes > 0
+            and self._shard_bytes + len(content) > self._shard_cap_bytes
+        ):
+            self._roll_shard()
+
+        self._indices.append(geometry_index)
+        self._contents.append(content)
+        self._ids.append(hashlib.sha256(content).hexdigest())
+        self._types.append(type_label)
+        self._buffered_bytes += len(content)
+        self._shard_bytes += len(content)
+
+        if (
+            self._buffered_bytes >= self._flush_bytes
+            or len(self._indices) >= _MAX_ROWS_PER_GROUP
+        ):
+            self._flush_row_group()
+
+    def _flush_row_group(self) -> None:
+        if not self._indices:
+            return
+        table = pa.Table.from_arrays(
+            [
+                pa.array(self._indices, type=pa.int32()),
+                pa.array(self._contents, type=pa.binary()),
+                pa.array(self._ids, type=pa.string()),
+                pa.array(self._types, type=pa.string()),
+            ],
+            schema=self._schema,
+        )
+        self._writer.write_table(table, row_group_size=len(table))
+        self._indices.clear()
+        self._contents.clear()
+        self._ids.clear()
+        self._types.clear()
+        self._buffered_bytes = 0

--- a/src/specklepy/bundle/geometries_writer.py
+++ b/src/specklepy/bundle/geometries_writer.py
@@ -1,16 +1,19 @@
-"""Writes ``geometries.parquet`` — one row per geometry: (geometryIndex, content, id, type).
+"""Writes ``geometries.parquet`` — one row per geometry: (geometryIndex, content,
+id, type).
 
-Port of the .NET ``GeometriesParquetWriter``. ``geometryIndex`` is the dense geometry-K
-the envelope's DISPLAY/DEFINES/HAS_MATERIAL edges reference (pure int, no applicationId
-strings). ``id`` is the SHA256 of the blob, kept as a column for READ-TIME shape dedup
-(the consumer collapses identical shapes into one GPU buffer); we do NOT content-dedup at
-write time, so every per-mesh row stays addressable and its material bindable.
+Port of the .NET ``GeometriesParquetWriter``. ``geometryIndex`` is the dense
+geometry-K the envelope's DISPLAY/DEFINES/HAS_MATERIAL edges reference (pure int, no
+applicationId strings). ``id`` is the SHA256 of the blob, kept as a column for
+READ-TIME shape dedup (the consumer collapses identical shapes into one GPU buffer);
+we do NOT content-dedup at write time, so every per-mesh row stays addressable and
+its material bindable.
 
-Sharded: shard 0 keeps the canonical ``{base}.geometries.parquet`` name (a model that fits
-in one shard is byte-for-byte unchanged); overflow shards are ``{base}.geometries.{N}.parquet``
-(N=1,2,…). Consumers read the set via the glob ``{base}.geometries*.parquet``. The cap is on
-UNCOMPRESSED content bytes, so the on-disk (Zstd) shard is always smaller than the cap — this
-contract is shared verbatim with the native nwextract ``GeomSharder`` (C++).
+Sharded: shard 0 keeps the canonical ``{base}.geometries.parquet`` name (a model that
+fits in one shard is byte-for-byte unchanged); overflow shards are
+``{base}.geometries.{N}.parquet`` (N=1,2,…). Consumers read the set via the glob
+``{base}.geometries*.parquet``. The cap is on UNCOMPRESSED content bytes, so the
+on-disk (Zstd) shard is always smaller than the cap — this contract is shared verbatim
+with the native nwextract ``GeomSharder`` (C++).
 """
 
 from __future__ import annotations
@@ -25,10 +28,12 @@ import pyarrow.parquet as pq
 from specklepy.bundle.parquet_table_writer import schema_of
 from specklepy.bundle.spec import BY_TABLE
 
-# Flush (write a row group + free the buffer) once buffered blob bytes reach this budget.
+# Flush (write a row group + free the buffer) once buffered blob bytes reach this
+# budget.
 _DEFAULT_ROWGROUP_MB = 64
 _MAX_ROWS_PER_GROUP = 200_000  # safety cap for tiny-blob models
-# Roll to a new shard once the current shard's uncompressed content bytes would exceed this.
+# Roll to a new shard once the current shard's uncompressed content bytes would
+# exceed this.
 _DEFAULT_SHARD_MB = 1536  # 1.5 GiB uncompressed content per shard
 
 _SGEO_HEADER_SIZE = 16
@@ -92,13 +97,15 @@ class GeometriesParquetWriter:
         self._buffered_bytes = 0
 
         self.geometries_path = self._shard_path(0)
-        # a previous run may have produced MORE shards than this one will — clear the whole set.
+        # a previous run may have produced MORE shards than this one will — clear the
+        # whole set.
         self._delete_stale_shards()
         self._open_shard(0)
 
     @property
     def geometry_paths(self) -> list[str]:
-        """Every geometry shard file written, in order (shard 0 = ``geometries_path``)."""
+        """Every geometry shard file written, in order (shard 0 =
+        ``geometries_path``)."""
         return list(self._geometry_paths)
 
     def add_geometry(self, geometry_index: int, sgeo: bytes) -> None:
@@ -115,7 +122,8 @@ class GeometriesParquetWriter:
     def add_raw_geometry(
         self, geometry_index: int, content: bytes, type_label: str
     ) -> None:
-        """Add one RAW (non-SGEO) blob verbatim with an explicit ``type`` label (e.g. "3dm")."""
+        """Add one RAW (non-SGEO) blob verbatim with an explicit ``type`` label
+        (e.g. "3dm")."""
         self._add_row(geometry_index, content, type_label)
 
     def complete(self) -> None:

--- a/src/specklepy/bundle/interner.py
+++ b/src/specklepy/bundle/interner.py
@@ -1,0 +1,40 @@
+"""Dense per-namespace ``str -> int`` interner for the bundle identity scheme.
+
+Each identity namespace (object / geometry / node) owns one interner; ids are ``0..N-1``
+in first-seen order. The same key always maps to the same id — how a value referenced
+from many edges (a shared material, a reused geometry) collapses to one ``K``.
+
+``get_or_add`` returns ``(id, is_new)``; ``is_new`` is True only when the key was just
+minted, so callers write the backing row (dictionary entry, node, geometry blob) exactly
+once. Not thread-safe: the converter loop is sequential. Port of the .NET ``IdInterner``.
+"""
+
+from __future__ import annotations
+
+
+class IdInterner:
+    def __init__(self) -> None:
+        self._map: dict[str, int] = {}
+
+    @property
+    def count(self) -> int:
+        """Number of distinct keys interned so far (also the next id to be minted)."""
+        return len(self._map)
+
+    def get_or_add(self, key: str) -> tuple[int, bool]:
+        """Resolve ``key`` to its dense id, minting on first sight.
+
+        Returns ``(id, is_new)``; ``is_new`` is True iff the key was newly added — the
+        caller should then write its backing row.
+        """
+        existing = self._map.get(key)
+        if existing is not None:
+            return existing, False
+        idx = len(self._map)
+        self._map[key] = idx
+        return idx, True
+
+    def intern(self, key: str) -> int:
+        """Convenience when the caller doesn't need the newly-added flag."""
+        idx, _ = self.get_or_add(key)
+        return idx

--- a/src/specklepy/bundle/interner.py
+++ b/src/specklepy/bundle/interner.py
@@ -5,8 +5,9 @@ in first-seen order. The same key always maps to the same id — how a value ref
 from many edges (a shared material, a reused geometry) collapses to one ``K``.
 
 ``get_or_add`` returns ``(id, is_new)``; ``is_new`` is True only when the key was just
-minted, so callers write the backing row (dictionary entry, node, geometry blob) exactly
-once. Not thread-safe: the converter loop is sequential. Port of the .NET ``IdInterner``.
+minted, so callers write the backing row (dictionary entry, node, geometry blob)
+exactly once. Not thread-safe: the converter loop is sequential. Port of the .NET
+``IdInterner``.
 """
 
 from __future__ import annotations

--- a/src/specklepy/bundle/parquet_table_writer.py
+++ b/src/specklepy/bundle/parquet_table_writer.py
@@ -38,7 +38,8 @@ _ARROW: dict[str, pa.DataType] = {
 
 
 def arrow_field(col: ColumnSpec) -> pa.Field:
-    """One pyarrow field from a generated column descriptor (name, type token, nullability)."""
+    """One pyarrow field from a generated column descriptor (name, type token,
+    nullability)."""
     try:
         dt = _ARROW[col.type]
     except KeyError as exc:  # pragma: no cover - guards a spec/codegen mismatch

--- a/src/specklepy/bundle/parquet_table_writer.py
+++ b/src/specklepy/bundle/parquet_table_writer.py
@@ -1,0 +1,116 @@
+"""Generic columnar Parquet table writer (Zstd), row-group-buffered.
+
+A passive columnar file: append row groups and close — no WAL/checkpoint/transaction
+manager/index. Memory is bounded by the in-flight row group (flushed on a row budget),
+so it scales to arbitrary row counts at constant memory. DuckDB reads it natively
+(``read_parquet('...')``). Port of the .NET ``ParquetTableWriter``.
+
+Unlike the .NET writer there is no background scheduler: the .NET version offloads the
+sync-over-async parquet IO to a worker thread only to keep it off the ODA-pinned
+extraction thread. specklepy has no such constraint, so writes happen inline.
+
+Rows are added as a positional sequence in schema-column order; nullable columns accept
+``None``. Not thread-safe: calls are sequential (converter loop).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Sequence
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from specklepy.bundle.spec import ColumnSpec
+
+DEFAULT_ROWGROUP_ROWS = 200_000
+
+# ColumnSpec.type token (from the generated spec) -> pyarrow type. The single mapping
+# point; every table schema is built from the spec descriptors, never hand-declared.
+_ARROW: dict[str, pa.DataType] = {
+    "int32": pa.int32(),
+    "int64": pa.int64(),
+    "string": pa.string(),
+    "float64": pa.float64(),
+    "bool": pa.bool_(),
+    "binary": pa.binary(),
+}
+
+
+def arrow_field(col: ColumnSpec) -> pa.Field:
+    """One pyarrow field from a generated column descriptor (name, type token, nullability)."""
+    try:
+        dt = _ARROW[col.type]
+    except KeyError as exc:  # pragma: no cover - guards a spec/codegen mismatch
+        raise NotImplementedError(
+            f"unmapped arrow type token '{col.type}' for column '{col.name}'"
+        ) from exc
+    return pa.field(col.name, dt, nullable=col.nullable)
+
+
+def schema_of(cols: Sequence[ColumnSpec]) -> pa.Schema:
+    """Build a pyarrow schema from the generated spec column descriptors."""
+    return pa.schema([arrow_field(c) for c in cols])
+
+
+class ParquetTableWriter:
+    """Buffers rows and flushes Zstd-compressed row groups to a single parquet file."""
+
+    def __init__(
+        self,
+        path: str,
+        schema: pa.Schema,
+        flush_rows: int = DEFAULT_ROWGROUP_ROWS,
+    ) -> None:
+        self.path = path
+        if os.path.exists(path):
+            os.remove(path)
+
+        self._schema = schema
+        self._flush_rows = flush_rows
+        # one buffer list per column, in schema order.
+        self._cols: list[list[Any]] = [[] for _ in range(len(schema))]
+        self._buffered = 0
+        self._completed = False
+        self._writer = pq.ParquetWriter(path, schema, compression="zstd")
+
+    def add_row(self, *values: Any) -> None:
+        """Append one row; ``values`` are in schema-column order."""
+        if self._completed:
+            raise RuntimeError("Writer already completed.")
+        if len(values) != len(self._cols):
+            raise ValueError(
+                f"{self.path}: expected {len(self._cols)} columns, got {len(values)}"
+            )
+        for col, v in zip(self._cols, values, strict=False):
+            col.append(v)
+        self._buffered += 1
+        if self._buffered >= self._flush_rows:
+            self._flush_row_group()
+
+    def complete(self) -> None:
+        """Flush the final row group and close the file (writes the footer/metadata)."""
+        if self._completed:
+            return
+        self._completed = True
+        self._flush_row_group()
+        self._writer.close()
+
+    def __enter__(self) -> ParquetTableWriter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.complete()
+
+    def _flush_row_group(self) -> None:
+        if self._buffered == 0:
+            return
+        arrays = [
+            pa.array(self._cols[i], type=self._schema.field(i).type)
+            for i in range(len(self._cols))
+        ]
+        table = pa.Table.from_arrays(arrays, schema=self._schema)
+        self._writer.write_table(table, row_group_size=len(table))
+        for col in self._cols:
+            col.clear()
+        self._buffered = 0

--- a/src/specklepy/bundle/pipeline.py
+++ b/src/specklepy/bundle/pipeline.py
@@ -1,17 +1,18 @@
 """Speckle 4.0 bundle producer — the typed emit API a converter drives.
 
-Port of the .NET ``ObjectsArtifactPipeline``. PARQUET-ONLY: direct Zstd parquet, one file
-per table, no DuckDB. Owns the three per-namespace identity interners and exposes a typed
-emit API so the producer stays string-based while the artefacts store pure dense int32:
+Port of the .NET ``ObjectsArtifactPipeline``. PARQUET-ONLY: direct Zstd parquet,
+one file per table, no DuckDB. Owns the three per-namespace identity interners and
+exposes a typed emit API so the producer stays string-based while the artefacts
+store pure dense int32:
 
-* **object** namespace — interned by the eav writer (eav is the dictionary home); resolved
-  here via :meth:`intern_object`.
+* **object** namespace — interned by the eav writer (eav is the dictionary home);
+  resolved here via :meth:`intern_object`.
 * **geometry** namespace — :attr:`_geometry_interner`; one row per mesh.
-* **node** namespace — :attr:`_node_interner` (kind-prefixed keys); definitions / instances
-  / materials / colours / levels / containers.
+* **node** namespace — :attr:`_node_interner` (kind-prefixed keys); definitions /
+  instances / materials / colours / levels / containers.
 
-Producing the files is decoupled from uploading: write here (:meth:`complete`), then hand
-the output dir to the uploader (:mod:`specklepy.bundle.upload`).
+Producing the files is decoupled from uploading: write here (:meth:`complete`), then
+hand the output dir to the uploader (:mod:`specklepy.bundle.upload`).
 """
 
 from __future__ import annotations
@@ -32,16 +33,17 @@ from specklepy.bundle.spec import NodeKind, Rel
 
 
 def _format_transform(transform: Sequence[float]) -> str:
-    """16 row-major doubles as a comma-separated string (consumer parses back to f64)."""
+    """16 row-major doubles as a comma-separated string (consumer parses to f64)."""
     return ",".join(repr(float(d)) for d in transform)
 
 
 def _argb_int32(argb: int) -> int:
     """Reinterpret a packed ARGB colour as a signed int32 (the `argb` column type).
 
-    Producers often hold ARGB as an unsigned 32-bit int (0..2^32-1); the bundle stores the
-    SAME 32 bits as a signed int32 (matching the .NET ``int`` storage), so the high-alpha
-    bit becomes the sign. Identity for values already in signed range.
+    Producers often hold ARGB as an unsigned 32-bit int (0..2^32-1); the bundle
+    stores the SAME 32 bits as a signed int32 (matching the .NET ``int`` storage),
+    so the high-alpha bit becomes the sign. Identity for values already in signed
+    range.
     """
     argb &= 0xFFFFFFFF
     return argb - 0x1_0000_0000 if argb >= 0x8000_0000 else argb
@@ -63,8 +65,8 @@ class ObjectsArtifactPipeline:
             else set(DEFAULT_EXCLUDED_TOP_LEVEL)
         )
 
-        # per-namespace interners. The object namespace is owned by the eav writer (it writes
-        # the dictionary), so it is not duplicated here.
+        # per-namespace interners. The object namespace is owned by the eav writer
+        # (it writes the dictionary), so it is not duplicated here.
         self._geometry_interner = IdInterner()
         self._node_interner = IdInterner()
 
@@ -78,7 +80,7 @@ class ObjectsArtifactPipeline:
     # ── object namespace ────────────────────────────────────────────────────
 
     def intern_object(self, application_id: str) -> int:
-        """Resolve an object's dense K (interns its applicationId via the eav dictionary)."""
+        """Resolve an object's dense K (interns its applicationId via eav dict)."""
         return self._eav.get_or_add_object(application_id)
 
     def add_properties(
@@ -90,9 +92,9 @@ class ObjectsArtifactPipeline:
     ) -> None:
         """Flatten an object's property tree into ``eav`` keyed by ``application_id``.
 
-        When ``type_key`` is given and there are type-scoped Parameters, those are deduped
-        into ``type_eav`` (once per type) with an ``object_type`` weak ref; otherwise
-        everything flattens per-object.
+        When ``type_key`` is given and there are type-scoped Parameters, those are
+        deduped into ``type_eav`` (once per type) with an ``object_type`` weak ref;
+        otherwise everything flattens per-object.
         """
         split = _try_split_type_parameters(properties) if type_key is not None else None
         if split is None:
@@ -116,8 +118,9 @@ class ObjectsArtifactPipeline:
     # ── geometry namespace ──────────────────────────────────────────────────
 
     def add_geometry(self, mesh_application_id: str, geometry: Any) -> int:
-        """Intern a mesh's applicationId to a dense geometry K, encoding + storing its SGEO
-        blob on first sight. Returns the K (for DISPLAY/DEFINES/HAS_MATERIAL edges)."""
+        """Intern a mesh's applicationId to a dense geometry K, encoding + storing
+        its SGEO blob on first sight. Returns the K (for DISPLAY/DEFINES/HAS_MATERIAL
+        edges)."""
         k, is_new = self._geometry_interner.get_or_add(mesh_application_id)
         if is_new:
             self._geometries.add_geometry(k, sgeo.encode(geometry))
@@ -126,7 +129,7 @@ class ObjectsArtifactPipeline:
     def add_raw_geometry(
         self, geometry_application_id: str, content: bytes, type_label: str
     ) -> int:
-        """Intern + store RAW bytes verbatim (no SGEO encoding) with an explicit type label."""
+        """Intern + store RAW bytes verbatim (no SGEO encoding) with a type label."""
         k, is_new = self._geometry_interner.get_or_add(geometry_application_id)
         if is_new:
             self._geometries.add_raw_geometry(k, content, type_label)
@@ -165,7 +168,8 @@ class ObjectsArtifactPipeline:
         transform: Sequence[float],
         units: str | None,
     ) -> int:
-        """Intern an INSTANCE (placement) node — its transform (16 row-major doubles) + DEFINITION."""
+        """Intern an INSTANCE (placement) node — its transform (16 row-major
+        doubles) + DEFINITION."""
         k, is_new = self._node_interner.get_or_add("inst:" + placement_key)
         if is_new:
             self._envelope.add_node(
@@ -259,11 +263,12 @@ class ObjectsArtifactPipeline:
         parent_collection_k: int | None,
         subtype: str | None,
     ) -> int:
-        """Intern a scene-tree collection (layer / category / story) node, writing it once.
+        """Intern a scene-tree collection (layer / category / story) node, once.
 
-        v5: a collection is a CONTAINER whose ``subtype`` carries its tag; the IN_COLLECTION
-        rel marks the grouping axis. ``parent_collection_k`` is its parent collection node
-        (None = top-level) — the parent chain IS the source hierarchy.
+        v5: a collection is a CONTAINER whose ``subtype`` carries its tag; the
+        IN_COLLECTION rel marks the grouping axis. ``parent_collection_k`` is its
+        parent collection node (None = top-level) — the parent chain IS the source
+        hierarchy.
         """
         k, is_new = self._node_interner.get_or_add("coll:" + collection_key)
         if is_new:
@@ -290,11 +295,12 @@ class ObjectsArtifactPipeline:
         parent_container_k: int | None,
         subtype: str | None,
     ) -> int:
-        """Intern a CONTAINER (semantic-topology bucket: model / room / system / …) node, once.
+        """Intern a CONTAINER (semantic-topology bucket: model / room / system / …)
+        node, once.
 
-        Distinct from :meth:`add_collection` (the authored scene-tree). ``subtype`` is the
-        canonical axis tag (e.g. "Model", "System") — use the SAME tag across connectors for
-        the same concept.
+        Distinct from :meth:`add_collection` (the authored scene-tree). ``subtype`` is
+        the canonical axis tag (e.g. "Model", "System") — use the SAME tag across
+        connectors for the same concept.
         """
         k, is_new = self._node_interner.get_or_add("cont:" + container_key)
         if is_new:
@@ -321,7 +327,7 @@ class ObjectsArtifactPipeline:
         self._envelope.add_relation(Rel.DISPLAY, object_k, geometry_k, ord)
 
     def display_instance(self, object_k: int, instance_k: int, ord: int) -> None:
-        """object → node(INSTANCE): renderable via a placement (transform + definition)."""
+        """object → node(INSTANCE): renderable via a placement (transform + def)."""
         self._envelope.add_relation(Rel.DISPLAY_INSTANCE, object_k, instance_k, ord)
 
     def solid(self, object_k: int, geometry_k: int, ord: int) -> None:
@@ -339,7 +345,8 @@ class ObjectsArtifactPipeline:
         self._envelope.add_relation(Rel.DEFINES, definition_k, geometry_k, ord)
 
     def defines_instance(self, definition_k: int, instance_k: int, ord: int) -> None:
-        """node(DEFINITION) → node(nested INSTANCE): definition contains a nested block placement."""
+        """node(DEFINITION) → node(nested INSTANCE): definition contains a nested
+        block placement."""
         self._envelope.add_relation(Rel.DEFINES_INSTANCE, definition_k, instance_k, ord)
 
     def has_material(self, geometry_k: int, material_k: int) -> None:
@@ -359,7 +366,8 @@ class ObjectsArtifactPipeline:
         self._envelope.add_relation(Rel.IN_COLLECTION, object_k, collection_k, ord)
 
     def in_model(self, object_k: int, model_k: int, ord: int) -> None:
-        """object → node(CONTAINER, subtype "Model"): source-document / host / linked-model membership."""
+        """object → node(CONTAINER, subtype "Model"): source-document / host /
+        linked-model membership."""
         self._envelope.add_relation(Rel.IN_MODEL, object_k, model_k, ord)
 
     def in_room(self, object_k: int, room_k: int, ord: int) -> None:
@@ -367,10 +375,11 @@ class ObjectsArtifactPipeline:
         self._envelope.add_relation(Rel.IN_ROOM, object_k, room_k, ord)
 
     def in_system(self, object_k: int, system_k: int, ord: int) -> None:
-        """object → node(CONTAINER, subtype "System"): named logical engineering system membership.
+        """object → node(CONTAINER, subtype "System"): named logical engineering
+        system membership.
 
-        Also the v5 home of physically-connected NETWORKS (subtype "Network") — IN_NETWORK
-        was collapsed into IN_SYSTEM.
+        Also the v5 home of physically-connected NETWORKS (subtype "Network") —
+        IN_NETWORK was collapsed into IN_SYSTEM.
         """
         self._envelope.add_relation(Rel.IN_SYSTEM, object_k, system_k, ord)
 
@@ -379,8 +388,8 @@ class ObjectsArtifactPipeline:
     ) -> None:
         """object → object: physical flow connectivity, DIRECTED src→dst by flow.
 
-        A reciprocal pair (a→b AND b→a) encodes undirected / unknown flow. ``ord`` is the
-        scope tag (system-K, or 0 = unscoped).
+        A reciprocal pair (a→b AND b→a) encodes undirected / unknown flow. ``ord`` is
+        the scope tag (system-K, or 0 = unscoped).
         """
         self._envelope.add_relation(
             Rel.CONNECTS_TO, source_object_k, target_object_k, ord
@@ -395,7 +404,7 @@ class ObjectsArtifactPipeline:
     # ── lifecycle ───────────────────────────────────────────────────────────
 
     def complete(self) -> None:
-        """Flush + finalize every artefact. All parquet files are fully written on return."""
+        """Flush + finalize every artefact. All parquet files written on return."""
         self._geometries.complete()
         self._envelope.complete()
         self._eav.complete()
@@ -407,8 +416,9 @@ class ObjectsArtifactPipeline:
         self.complete()
 
 
-# Splits `properties.Parameters` into instance-scoped (kept on the object) and type-scoped
-# (Type + System Parameters, deduped per type). Returns None if there's nothing type-scoped.
+# Splits `properties.Parameters` into instance-scoped (kept on the object) and
+# type-scoped (Type + System Parameters, deduped per type). Returns None if there's
+# nothing type-scoped.
 def _try_split_type_parameters(
     properties: Mapping[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]] | None:

--- a/src/specklepy/bundle/pipeline.py
+++ b/src/specklepy/bundle/pipeline.py
@@ -1,0 +1,432 @@
+"""Speckle 4.0 bundle producer — the typed emit API a converter drives.
+
+Port of the .NET ``ObjectsArtifactPipeline``. PARQUET-ONLY: direct Zstd parquet, one file
+per table, no DuckDB. Owns the three per-namespace identity interners and exposes a typed
+emit API so the producer stays string-based while the artefacts store pure dense int32:
+
+* **object** namespace — interned by the eav writer (eav is the dictionary home); resolved
+  here via :meth:`intern_object`.
+* **geometry** namespace — :attr:`_geometry_interner`; one row per mesh.
+* **node** namespace — :attr:`_node_interner` (kind-prefixed keys); definitions / instances
+  / materials / colours / levels / containers.
+
+Producing the files is decoupled from uploading: write here (:meth:`complete`), then hand
+the output dir to the uploader (:mod:`specklepy.bundle.upload`).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from specklepy.bundle import sgeo
+from specklepy.bundle.eav_extraction import (
+    DEFAULT_EXCLUDED_TOP_LEVEL,
+    flatten_properties,
+    flatten_subtree,
+)
+from specklepy.bundle.eav_writer import EavWriter
+from specklepy.bundle.envelope_writer import EnvelopeWriter, SceneView
+from specklepy.bundle.geometries_writer import GeometriesParquetWriter
+from specklepy.bundle.interner import IdInterner
+from specklepy.bundle.spec import NodeKind, Rel
+
+
+def _format_transform(transform: Sequence[float]) -> str:
+    """16 row-major doubles as a comma-separated string (consumer parses back to f64)."""
+    return ",".join(repr(float(d)) for d in transform)
+
+
+def _argb_int32(argb: int) -> int:
+    """Reinterpret a packed ARGB colour as a signed int32 (the `argb` column type).
+
+    Producers often hold ARGB as an unsigned 32-bit int (0..2^32-1); the bundle stores the
+    SAME 32 bits as a signed int32 (matching the .NET ``int`` storage), so the high-alpha
+    bit becomes the sign. Identity for values already in signed range.
+    """
+    argb &= 0xFFFFFFFF
+    return argb - 0x1_0000_0000 if argb >= 0x8000_0000 else argb
+
+
+class ObjectsArtifactPipeline:
+    def __init__(
+        self,
+        output_dir: str,
+        base_name: str,
+        excluded_top_level_properties: set[str] | None = None,
+    ) -> None:
+        self._geometries = GeometriesParquetWriter(output_dir, base_name)
+        self._envelope = EnvelopeWriter(output_dir, base_name)
+        self._eav = EavWriter(output_dir, base_name)
+        self._excluded = (
+            excluded_top_level_properties
+            if excluded_top_level_properties is not None
+            else set(DEFAULT_EXCLUDED_TOP_LEVEL)
+        )
+
+        # per-namespace interners. The object namespace is owned by the eav writer (it writes
+        # the dictionary), so it is not duplicated here.
+        self._geometry_interner = IdInterner()
+        self._node_interner = IdInterner()
+
+        self.output_dir = output_dir
+        self.base_name = base_name
+
+    @property
+    def geometries_path(self) -> str:
+        return self._geometries.geometries_path
+
+    # ── object namespace ────────────────────────────────────────────────────
+
+    def intern_object(self, application_id: str) -> int:
+        """Resolve an object's dense K (interns its applicationId via the eav dictionary)."""
+        return self._eav.get_or_add_object(application_id)
+
+    def add_properties(
+        self,
+        application_id: str,
+        properties: Mapping[str, Any],
+        root_scalars: Iterable[tuple[str, Any]] | None = None,
+        type_key: str | None = None,
+    ) -> None:
+        """Flatten an object's property tree into ``eav`` keyed by ``application_id``.
+
+        When ``type_key`` is given and there are type-scoped Parameters, those are deduped
+        into ``type_eav`` (once per type) with an ``object_type`` weak ref; otherwise
+        everything flattens per-object.
+        """
+        split = _try_split_type_parameters(properties) if type_key is not None else None
+        if split is None:
+            rows = flatten_properties(
+                application_id, properties, root_scalars, self._excluded
+            )
+            self._eav.add_rows(application_id, rows)
+            return
+
+        instance_props, type_subtree = split
+        instance_rows = flatten_properties(
+            application_id, instance_props, root_scalars, self._excluded
+        )
+        self._eav.add_rows(application_id, instance_rows)
+        self._eav.add_type(
+            application_id,
+            type_key,
+            lambda: flatten_subtree(type_subtree, "properties.Parameters"),
+        )
+
+    # ── geometry namespace ──────────────────────────────────────────────────
+
+    def add_geometry(self, mesh_application_id: str, geometry: Any) -> int:
+        """Intern a mesh's applicationId to a dense geometry K, encoding + storing its SGEO
+        blob on first sight. Returns the K (for DISPLAY/DEFINES/HAS_MATERIAL edges)."""
+        k, is_new = self._geometry_interner.get_or_add(mesh_application_id)
+        if is_new:
+            self._geometries.add_geometry(k, sgeo.encode(geometry))
+        return k
+
+    def add_raw_geometry(
+        self, geometry_application_id: str, content: bytes, type_label: str
+    ) -> int:
+        """Intern + store RAW bytes verbatim (no SGEO encoding) with an explicit type label."""
+        k, is_new = self._geometry_interner.get_or_add(geometry_application_id)
+        if is_new:
+            self._geometries.add_raw_geometry(k, content, type_label)
+        return k
+
+    def intern_geometry_id(self, mesh_application_id: str) -> int:
+        """Resolve the geometry K for an already-added mesh (lookup, no encode)."""
+        return self._geometry_interner.intern(mesh_application_id)
+
+    # ── node namespace (value-entities) ─────────────────────────────────────
+
+    def add_definition(self, definition_key: str, name: str | None) -> int:
+        """Intern a DEFINITION node (instance-definition / block), writing it once."""
+        k, is_new = self._node_interner.get_or_add("def:" + definition_key)
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.DEFINITION,
+                name,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        return k
+
+    def add_instance(
+        self,
+        placement_key: str,
+        def_ref: int,
+        transform: Sequence[float],
+        units: str | None,
+    ) -> int:
+        """Intern an INSTANCE (placement) node — its transform (16 row-major doubles) + DEFINITION."""
+        k, is_new = self._node_interner.get_or_add("inst:" + placement_key)
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.INSTANCE,
+                None,
+                def_ref,
+                _format_transform(transform),
+                units,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        return k
+
+    def add_material(
+        self,
+        material_key: str,
+        argb: int,
+        opacity: float,
+        metalness: float,
+        roughness: float,
+    ) -> int:
+        """Intern a MATERIAL value-node (inline render value), writing it once."""
+        k, is_new = self._node_interner.get_or_add("mat:" + material_key)
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.MATERIAL,
+                None,
+                None,
+                None,
+                None,
+                None,
+                _argb_int32(argb),
+                opacity,
+                metalness,
+                roughness,
+                None,
+            )
+        return k
+
+    def add_color(self, argb: int) -> int:
+        """Intern a COLOR value-node (keyed by its argb), writing it once."""
+        signed = _argb_int32(argb)
+        k, is_new = self._node_interner.get_or_add("col:" + str(signed))
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.COLOR,
+                None,
+                None,
+                None,
+                None,
+                None,
+                signed,
+                None,
+                None,
+                None,
+                None,
+            )
+        return k
+
+    def add_level(self, level_key: str, name: str | None, elevation: float) -> int:
+        """Intern a LEVEL value-node (name + elevation), writing it once."""
+        k, is_new = self._node_interner.get_or_add("lvl:" + level_key)
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.LEVEL,
+                name,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                elevation,
+            )
+        return k
+
+    def add_collection(
+        self,
+        collection_key: str,
+        name: str | None,
+        parent_collection_k: int | None,
+        subtype: str | None,
+    ) -> int:
+        """Intern a scene-tree collection (layer / category / story) node, writing it once.
+
+        v5: a collection is a CONTAINER whose ``subtype`` carries its tag; the IN_COLLECTION
+        rel marks the grouping axis. ``parent_collection_k`` is its parent collection node
+        (None = top-level) — the parent chain IS the source hierarchy.
+        """
+        k, is_new = self._node_interner.get_or_add("coll:" + collection_key)
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.CONTAINER,
+                name,
+                parent_collection_k,
+                None,
+                None,
+                subtype,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        return k
+
+    def add_container(
+        self,
+        container_key: str,
+        name: str | None,
+        parent_container_k: int | None,
+        subtype: str | None,
+    ) -> int:
+        """Intern a CONTAINER (semantic-topology bucket: model / room / system / …) node, once.
+
+        Distinct from :meth:`add_collection` (the authored scene-tree). ``subtype`` is the
+        canonical axis tag (e.g. "Model", "System") — use the SAME tag across connectors for
+        the same concept.
+        """
+        k, is_new = self._node_interner.get_or_add("cont:" + container_key)
+        if is_new:
+            self._envelope.add_node(
+                k,
+                NodeKind.CONTAINER,
+                name,
+                parent_container_k,
+                None,
+                None,
+                subtype,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        return k
+
+    # ── relations ───────────────────────────────────────────────────────────
+
+    def display(self, object_k: int, geometry_k: int, ord: int) -> None:
+        """object → geometry: direct renderable geometry (world-coord mesh)."""
+        self._envelope.add_relation(Rel.DISPLAY, object_k, geometry_k, ord)
+
+    def display_instance(self, object_k: int, instance_k: int, ord: int) -> None:
+        """object → node(INSTANCE): renderable via a placement (transform + definition)."""
+        self._envelope.add_relation(Rel.DISPLAY_INSTANCE, object_k, instance_k, ord)
+
+    def solid(self, object_k: int, geometry_k: int, ord: int) -> None:
+        """object → geometry: authoritative solid."""
+        self._envelope.add_relation(Rel.SOLID, object_k, geometry_k, ord)
+
+    def subelement(self, parent_object_k: int, child_object_k: int, ord: int) -> None:
+        """object → object: host→hosted (curtain wall → panel)."""
+        self._envelope.add_relation(
+            Rel.SUBELEMENT, parent_object_k, child_object_k, ord
+        )
+
+    def defines(self, definition_k: int, geometry_k: int, ord: int) -> None:
+        """node(DEFINITION) → geometry: definition contains a raw mesh member."""
+        self._envelope.add_relation(Rel.DEFINES, definition_k, geometry_k, ord)
+
+    def defines_instance(self, definition_k: int, instance_k: int, ord: int) -> None:
+        """node(DEFINITION) → node(nested INSTANCE): definition contains a nested block placement."""
+        self._envelope.add_relation(Rel.DEFINES_INSTANCE, definition_k, instance_k, ord)
+
+    def has_material(self, geometry_k: int, material_k: int) -> None:
+        """geometry → node(MATERIAL): per-mesh render material."""
+        self._envelope.add_relation(Rel.HAS_MATERIAL, geometry_k, material_k, 0)
+
+    def has_color(self, src_k: int, color_k: int) -> None:
+        """geometry | object → node(COLOR): display colour."""
+        self._envelope.add_relation(Rel.HAS_COLOR, src_k, color_k, 0)
+
+    def on_level(self, object_k: int, level_k: int) -> None:
+        """object → node(LEVEL): level membership."""
+        self._envelope.add_relation(Rel.ON_LEVEL, object_k, level_k, 0)
+
+    def in_collection(self, object_k: int, collection_k: int, ord: int) -> None:
+        """object → node(COLLECTION): direct membership in a scene-tree container."""
+        self._envelope.add_relation(Rel.IN_COLLECTION, object_k, collection_k, ord)
+
+    def in_model(self, object_k: int, model_k: int, ord: int) -> None:
+        """object → node(CONTAINER, subtype "Model"): source-document / host / linked-model membership."""
+        self._envelope.add_relation(Rel.IN_MODEL, object_k, model_k, ord)
+
+    def in_room(self, object_k: int, room_k: int, ord: int) -> None:
+        """object → node(CONTAINER, subtype "Room"): room containment."""
+        self._envelope.add_relation(Rel.IN_ROOM, object_k, room_k, ord)
+
+    def in_system(self, object_k: int, system_k: int, ord: int) -> None:
+        """object → node(CONTAINER, subtype "System"): named logical engineering system membership.
+
+        Also the v5 home of physically-connected NETWORKS (subtype "Network") — IN_NETWORK
+        was collapsed into IN_SYSTEM.
+        """
+        self._envelope.add_relation(Rel.IN_SYSTEM, object_k, system_k, ord)
+
+    def connects_to(
+        self, source_object_k: int, target_object_k: int, ord: int = 0
+    ) -> None:
+        """object → object: physical flow connectivity, DIRECTED src→dst by flow.
+
+        A reciprocal pair (a→b AND b→a) encodes undirected / unknown flow. ``ord`` is the
+        scope tag (system-K, or 0 = unscoped).
+        """
+        self._envelope.add_relation(
+            Rel.CONNECTS_TO, source_object_k, target_object_k, ord
+        )
+
+    # ── scene views ─────────────────────────────────────────────────────────
+
+    def add_scene_view(self, view: SceneView) -> None:
+        """Author a scene_views projection (SOT §8): the producer's default grouping."""
+        self._envelope.add_scene_view(view)
+
+    # ── lifecycle ───────────────────────────────────────────────────────────
+
+    def complete(self) -> None:
+        """Flush + finalize every artefact. All parquet files are fully written on return."""
+        self._geometries.complete()
+        self._envelope.complete()
+        self._eav.complete()
+
+    def __enter__(self) -> ObjectsArtifactPipeline:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.complete()
+
+
+# Splits `properties.Parameters` into instance-scoped (kept on the object) and type-scoped
+# (Type + System Parameters, deduped per type). Returns None if there's nothing type-scoped.
+def _try_split_type_parameters(
+    properties: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    params = properties.get("Parameters")
+    if not isinstance(params, Mapping):
+        return None
+
+    type_params: dict[str, Any] = {}
+    instance_params: dict[str, Any] = {}
+    for key, value in params.items():
+        if key in ("Type Parameters", "System Type Parameters"):
+            type_params[key] = value
+        else:
+            instance_params[key] = value
+
+    if not type_params:
+        return None
+
+    merged = dict(properties)
+    merged["Parameters"] = instance_params
+    return merged, type_params

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -206,8 +206,9 @@ def _encode_mesh(m) -> bytes:
     body = bytearray()
     _u32(body, len(m.vertices) // 3)
     _u32(body, len(m.faces))
-    # Batched packs: one struct.pack per array (C-level) instead of one call per scalar —
-    # the per-double/-int loop was a hot spot on dense meshes. Byte layout is unchanged.
+    # Batched packs: one struct.pack per array (C-level) instead of one call per
+    # scalar — the per-double/-int loop was a hot spot on dense meshes. Byte layout
+    # is unchanged.
     _f64_array(body, m.vertices)
     _i32_array(body, m.faces)
     if has_normals:

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -1,0 +1,469 @@
+"""SGEO v1 geometry encoder — a byte-for-byte port of the .NET ``SgeoEncoder``.
+
+SGEO is Speckle's binary geometry-family format: one opaque blob per geometry
+buffer, a fixed 16-byte little-endian header followed by a per-primitive body.
+The SDK owns the format; this module mirrors the C# encoder in
+``Speckle.Objects/Utils/SgeoEncoder.cs`` exactly so that connectors written in
+Python produce identical bytes.
+
+Header (16 bytes, little-endian)::
+
+    0x00  4  magic           b"SGEO"
+    0x04  1  version         = 1
+    0x05  1  primitive_type  see PrimitiveType
+    0x06  2  flags           uint16 (see Flags)
+    0x08  2  units_code      uint16, mirrors Units.GetEncodingFromUnit
+    0x0A  2  reserved        = 0
+    0x0C  4  crc             CRC32 of body bytes only (0x10..end)
+    0x10  …  body            per primitive_type
+
+Conventions: little-endian throughout; f64 = IEEE-754 double; the body starts
+8-byte aligned at 0x10 and every f64 array stays 8-aligned (u32 scalars are
+padded in pairs via :func:`_pad8`).
+"""
+
+from __future__ import annotations
+
+import struct
+from enum import IntEnum, IntFlag
+from typing import Optional
+
+MAGIC = b"SGEO"
+VERSION_1 = 1
+HEADER_SIZE = 16
+ENCODING_NAME = "sgeo_v1"
+
+
+class PrimitiveType(IntEnum):
+    """SGEO primitive type codes (header offset 0x05, one byte)."""
+
+    MESH = 0
+    LINE = 1
+    POLYLINE = 2
+    POLYCURVE = 3
+    CURVE = 4
+    ARC = 5
+    CIRCLE = 6
+    POINTS = 7
+    ELLIPSE = 8
+    SPIRAL = 9
+    BOX = 10
+
+
+class Flags(IntFlag):
+    """SGEO header flags (offset 0x06, uint16 bitfield)."""
+
+    NONE = 0
+    QUANTIZED = 1 << 0
+    CLOSED = 1 << 1
+    RATIONAL = 1 << 2
+    PERIODIC = 1 << 3
+    HAS_NORMALS = 1 << 4
+    HAS_UVS = 1 << 5
+    HAS_COLORS = 1 << 6
+    HAS_SIZES = 1 << 7
+    HAS_TRIM_DOMAIN = 1 << 8
+
+
+# Mirrors Speckle.Sdk.Common.Units.GetEncodingFromUnit: the exact semantic unit
+# strings map to 1..8, anything else (aliases, unknown, none) silently maps to 0.
+_UNIT_ENCODING = {
+    "mm": 1,
+    "cm": 2,
+    "m": 3,
+    "km": 4,
+    "in": 5,
+    "ft": 6,
+    "yd": 7,
+    "mi": 8,
+}
+
+
+def get_encoding_from_unit(units: Optional[str]) -> int:
+    """Map a semantic unit string to its SGEO uint16 code (0 if unrecognised)."""
+    return _UNIT_ENCODING.get(units or "", 0)
+
+
+# ── CRC32 (IEEE 802.3, polynomial 0xEDB88820) ──────────────────────────────
+
+
+def _build_crc_table() -> list[int]:
+    table = []
+    for i in range(256):
+        c = i
+        for _ in range(8):
+            c = (0xEDB88820 ^ (c >> 1)) if (c & 1) else (c >> 1)
+        table.append(c)
+    return table
+
+
+_CRC_TABLE = _build_crc_table()
+
+
+def crc32(data: bytes) -> int:
+    """SGEO body CRC — a direct port of SgeoFormat.Crc32 (poly ``0xEDB88820``).
+
+    WARNING: the .NET SDK's ``Crc32`` uses the constant ``0xEDB88820`` (see
+    ``SgeoFormat.cs``), which is NOT the canonical IEEE-802.3 reflected
+    polynomial ``0xEDB88320``. The two differ by one bit, so SGEO's CRC does
+    NOT match :func:`zlib.crc32`. We deliberately replicate the .NET constant
+    so the header bytes are byte-for-byte identical to the C# encoder; do not
+    "optimise" this to ``zlib.crc32`` — that would corrupt cross-SDK decoding.
+    """
+    crc = 0xFFFFFFFF
+    for b in data:
+        crc = _CRC_TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc ^ 0xFFFFFFFF
+
+
+# ── low-level body writers ─────────────────────────────────────────────────
+
+
+def _f64(b: bytearray, v: float) -> None:
+    b += struct.pack("<d", v)
+
+
+def _i32(b: bytearray, v: int) -> None:
+    # Low 32 bits, matching C# AddInt32's (byte)(v >> 8*i) over a 32-bit int.
+    b += struct.pack("<I", v & 0xFFFFFFFF)
+
+
+def _u32(b: bytearray, v: int) -> None:
+    b += struct.pack("<I", v & 0xFFFFFFFF)
+
+
+def _pad8(b: bytearray) -> None:
+    while len(b) % 8 != 0:
+        b.append(0)
+
+
+def _point(b: bytearray, p) -> None:
+    _f64(b, p.x)
+    _f64(b, p.y)
+    _f64(b, p.z)
+
+
+def _vector(b: bytearray, v) -> None:
+    _f64(b, v.x)
+    _f64(b, v.y)
+    _f64(b, v.z)
+
+
+def _plane(b: bytearray, p) -> None:
+    _point(b, p.origin)
+    _vector(b, p.normal)
+    _vector(b, p.xdir)
+    _vector(b, p.ydir)
+
+
+def _polyline_body(b: bytearray, p) -> None:
+    # Shared by EncodePolyline and the curve/spiral leading render polyline.
+    if len(p.value) % 3 != 0:
+        raise ValueError("Polyline.value length must be a multiple of 3.")
+    _u32(b, len(p.value) // 3)
+    _u32(b, 0)
+    for v in p.value:
+        _f64(b, v)
+    _pad8(b)
+
+
+def _assemble(
+    primitive_type: PrimitiveType, flags: Flags, units: Optional[str], body: bytearray
+) -> bytes:
+    buf = bytearray(HEADER_SIZE + len(body))
+    buf[0:4] = MAGIC  # 0x00..0x03
+    buf[4] = VERSION_1  # 0x04
+    buf[5] = int(primitive_type)  # 0x05
+    struct.pack_into("<H", buf, 6, int(flags))  # 0x06 flags
+    struct.pack_into("<H", buf, 8, get_encoding_from_unit(units))  # 0x08 units
+    struct.pack_into("<H", buf, 10, 0)  # 0x0A reserved
+    buf[HEADER_SIZE:] = body
+    # Must use the ported crc32 (poly 0xEDB88820), NOT zlib — see crc32 docstring.
+    crc = crc32(bytes(body))
+    struct.pack_into("<I", buf, 12, crc)  # 0x0C crc
+    return bytes(buf)
+
+
+# ── per-primitive encoders ─────────────────────────────────────────────────
+
+
+def _encode_mesh(m) -> bytes:
+    if len(m.vertices) % 3 != 0:
+        raise ValueError("Mesh.vertices length must be a multiple of 3.")
+    has_normals = len(m.vertexNormals) > 0
+    has_uvs = len(m.textureCoordinates) > 0
+    has_colors = len(m.colors) > 0
+
+    flags = Flags.NONE
+    if has_normals:
+        flags |= Flags.HAS_NORMALS
+    if has_uvs:
+        flags |= Flags.HAS_UVS
+    if has_colors:
+        flags |= Flags.HAS_COLORS
+
+    body = bytearray()
+    _u32(body, len(m.vertices) // 3)
+    _u32(body, len(m.faces))
+    for v in m.vertices:
+        _f64(body, v)
+    for f in m.faces:
+        _i32(body, f)
+    if has_normals:
+        _pad8(body)
+        for n in m.vertexNormals:
+            _f64(body, n)
+    if has_uvs:
+        _pad8(body)
+        for t in m.textureCoordinates:
+            _f64(body, t)
+    if has_colors:
+        # NB: no pad before colors — matches the C# encoder exactly.
+        for c in m.colors:
+            _i32(body, c)
+
+    return _assemble(PrimitiveType.MESH, flags, m.units, body)
+
+
+def _encode_line(line) -> bytes:
+    body = bytearray()
+    _f64(body, line.domain.start)
+    _f64(body, line.domain.end)
+    _point(body, line.start)
+    _point(body, line.end)
+    return _assemble(PrimitiveType.LINE, Flags.NONE, line.units, body)
+
+
+def _encode_polyline(p) -> bytes:
+    if len(p.value) % 3 != 0:
+        raise ValueError("Polyline.value length must be a multiple of 3.")
+    flags = Flags.CLOSED if _is_closed(p) else Flags.NONE
+    body = bytearray()
+    _u32(body, len(p.value) // 3)
+    _u32(body, 0)
+    for v in p.value:
+        _f64(body, v)
+    return _assemble(PrimitiveType.POLYLINE, flags, p.units, body)
+
+
+def _encode_polycurve(pc) -> bytes:
+    flags = Flags.CLOSED if _is_closed(pc) else Flags.NONE
+    body = bytearray()
+    _u32(body, len(pc.segments))
+    _u32(body, 0)
+    for seg in pc.segments:
+        blob = encode(seg)
+        _u32(body, len(blob))
+        _u32(body, 0)
+        body += blob
+        _pad8(body)
+    return _assemble(PrimitiveType.POLYCURVE, flags, pc.units, body)
+
+
+def _encode_curve(c) -> bytes:
+    if len(c.points) % 3 != 0:
+        raise ValueError("Curve.points length must be a multiple of 3.")
+    flags = Flags.NONE
+    if _is_closed(c.displayValue):
+        flags |= Flags.CLOSED
+    if c.rational:
+        flags |= Flags.RATIONAL
+    if c.periodic:
+        flags |= Flags.PERIODIC
+
+    body = bytearray()
+    _polyline_body(body, c.displayValue)  # [render] leading displayValue polyline
+    _u32(body, c.degree)  # [analytical] trailing NURBS definition
+    _u32(body, len(c.points) // 3)
+    _u32(body, len(c.knots))
+    _u32(body, 0)
+    _f64(body, c.domain.start)
+    _f64(body, c.domain.end)
+    for p in c.points:
+        _f64(body, p)
+    if c.rational:
+        for w in c.weights:
+            _f64(body, w)
+    for k in c.knots:
+        _f64(body, k)
+    return _assemble(PrimitiveType.CURVE, flags, c.units, body)
+
+
+def _encode_arc(a) -> bytes:
+    body = bytearray()
+    _plane(body, a.plane)
+    _point(body, a.startPoint)
+    _point(body, a.midPoint)
+    _point(body, a.endPoint)
+    _f64(body, a.domain.start)
+    _f64(body, a.domain.end)
+    return _assemble(PrimitiveType.ARC, Flags.NONE, a.units, body)
+
+
+def _encode_circle(c) -> bytes:
+    body = bytearray()
+    _f64(body, c.radius)
+    _f64(body, c.domain.start)
+    _f64(body, c.domain.end)
+    _plane(body, c.plane)
+    return _assemble(PrimitiveType.CIRCLE, Flags.NONE, c.units, body)
+
+
+def _encode_point(pt) -> bytes:
+    body = bytearray()
+    _u32(body, 1)
+    _u32(body, 0)
+    _point(body, pt)
+    return _assemble(PrimitiveType.POINTS, Flags.NONE, pt.units, body)
+
+
+def _encode_pointcloud(pcl) -> bytes:
+    # specklepy stores points as a list of Point objects (vs the C# flat double
+    # list); flatten to x,y,z so the on-wire layout matches.
+    points = pcl.points
+    coords: list[float] = []
+    for p in points:
+        coords.extend((p.x, p.y, p.z))
+    colors = list(getattr(pcl, "colors", []) or [])
+    sizes = list(getattr(pcl, "sizes", []) or [])
+    has_colors = len(colors) > 0
+    has_sizes = len(sizes) > 0
+    flags = Flags.NONE
+    if has_colors:
+        flags |= Flags.HAS_COLORS
+    if has_sizes:
+        flags |= Flags.HAS_SIZES
+
+    body = bytearray()
+    _u32(body, len(coords) // 3)
+    _u32(body, 0)
+    for v in coords:
+        _f64(body, v)
+    if has_colors:
+        for c in colors:
+            _i32(body, c)
+    if has_sizes:
+        _pad8(body)
+        for s in sizes:
+            _f64(body, s)
+    return _assemble(PrimitiveType.POINTS, flags, pcl.units, body)
+
+
+def _encode_ellipse(e) -> bytes:
+    trim_domain = getattr(e, "trimDomain", None)
+    flags = Flags.HAS_TRIM_DOMAIN if trim_domain is not None else Flags.NONE
+    body = bytearray()
+    _f64(body, e.first_radius)
+    _f64(body, e.second_radius)
+    _f64(body, e.domain.start)
+    _f64(body, e.domain.end)
+    _plane(body, e.plane)
+    if trim_domain is not None:
+        _f64(body, trim_domain.start)
+        _f64(body, trim_domain.end)
+    return _assemble(PrimitiveType.ELLIPSE, flags, e.units, body)
+
+
+def _encode_spiral(s) -> bytes:
+    display_value = getattr(s, "displayValue", None)
+    is_closed = display_value is not None and _is_closed(display_value)
+    flags = Flags.CLOSED if is_closed else Flags.NONE
+    body = bytearray()
+    if display_value is not None:  # [render] leading displayValue polyline
+        _polyline_body(body, display_value)
+    else:
+        _u32(body, 0)
+        _u32(body, 0)
+        _pad8(body)
+    _u32(body, int(getattr(s, "spiralType", 0)))  # [analytical] trailing definition
+    _u32(body, 0)
+    _point(body, s.start_point)
+    _point(body, s.end_point)
+    _plane(body, s.plane)
+    _f64(body, s.turns)
+    _vector(body, s.pitch_axis)
+    _f64(body, s.pitch)
+    _f64(body, s.domain.start)
+    _f64(body, s.domain.end)
+    return _assemble(PrimitiveType.SPIRAL, flags, s.units, body)
+
+
+def _encode_box(b) -> bytes:
+    body = bytearray()
+    _plane(body, b.basePlane)
+    _f64(body, b.xSize.start)
+    _f64(body, b.xSize.end)
+    _f64(body, b.ySize.start)
+    _f64(body, b.ySize.end)
+    _f64(body, b.zSize.start)
+    _f64(body, b.zSize.end)
+    return _assemble(PrimitiveType.BOX, Flags.NONE, b.units, body)
+
+
+def _is_closed(curve) -> bool:
+    closed = getattr(curve, "closed", None)
+    if closed is not None:
+        return bool(closed)
+    is_closed = getattr(curve, "is_closed", None)
+    if callable(is_closed):
+        return bool(is_closed())
+    return False
+
+
+# ── public API ─────────────────────────────────────────────────────────────
+
+# Lazy import map: speckle_type string -> encoder. Keyed by class name to avoid
+# importing the whole geometry package at module load and to dodge cycles.
+_ENCODERS = {
+    "Mesh": _encode_mesh,
+    "Line": _encode_line,
+    "Polyline": _encode_polyline,
+    "Polycurve": _encode_polycurve,
+    "Curve": _encode_curve,
+    "Arc": _encode_arc,
+    "Circle": _encode_circle,
+    "Point": _encode_point,
+    "PointCloud": _encode_pointcloud,
+    "Ellipse": _encode_ellipse,
+    "Spiral": _encode_spiral,
+    "Box": _encode_box,
+}
+
+_PRIMITIVE_TYPES = {
+    "Mesh": PrimitiveType.MESH,
+    "Line": PrimitiveType.LINE,
+    "Polyline": PrimitiveType.POLYLINE,
+    "Polycurve": PrimitiveType.POLYCURVE,
+    "Curve": PrimitiveType.CURVE,
+    "Arc": PrimitiveType.ARC,
+    "Circle": PrimitiveType.CIRCLE,
+    "Point": PrimitiveType.POINTS,
+    "PointCloud": PrimitiveType.POINTS,
+    "Ellipse": PrimitiveType.ELLIPSE,
+    "Spiral": PrimitiveType.SPIRAL,
+    "Box": PrimitiveType.BOX,
+}
+
+
+def encode(geometry) -> bytes:
+    """Encode a supported geometry object into an SGEO v1 blob.
+
+    Dispatches on the object's class name (mirroring ``SgeoEncoder.Encode``).
+
+    Raises:
+        ValueError: when the geometry type has no SGEO mapping.
+    """
+    if geometry is None:
+        raise ValueError("Cannot encode None geometry.")
+    encoder = _ENCODERS.get(type(geometry).__name__)
+    if encoder is None:
+        raise ValueError(
+            f"No SGEO encoding for geometry type '{type(geometry).__name__}'."
+        )
+    return encoder(geometry)
+
+
+def try_get_primitive_type(geometry) -> Optional[int]:
+    """Return the SGEO primitive type code if encodable, else ``None``."""
+    primitive = _PRIMITIVE_TYPES.get(type(geometry).__name__)
+    return int(primitive) if primitive is not None else None

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -25,6 +25,7 @@ padded in pairs via :func:`_pad8`).
 from __future__ import annotations
 
 import struct
+import zlib
 from enum import IntEnum, IntFlag
 from typing import Optional
 
@@ -87,33 +88,17 @@ def get_encoding_from_unit(units: Optional[str]) -> int:
 # ── CRC32 (IEEE 802.3, polynomial 0xEDB88820) ──────────────────────────────
 
 
-def _build_crc_table() -> list[int]:
-    table = []
-    for i in range(256):
-        c = i
-        for _ in range(8):
-            c = (0xEDB88820 ^ (c >> 1)) if (c & 1) else (c >> 1)
-        table.append(c)
-    return table
-
-
-_CRC_TABLE = _build_crc_table()
-
-
 def crc32(data: bytes) -> int:
-    """SGEO body CRC — a direct port of SgeoFormat.Crc32 (poly ``0xEDB88820``).
+    """SGEO body CRC — canonical CRC-32 (IEEE 802.3, reflected poly ``0xEDB88320``).
 
-    WARNING: the .NET SDK's ``Crc32`` uses the constant ``0xEDB88820`` (see
-    ``SgeoFormat.cs``), which is NOT the canonical IEEE-802.3 reflected
-    polynomial ``0xEDB88320``. The two differ by one bit, so SGEO's CRC does
-    NOT match :func:`zlib.crc32`. We deliberately replicate the .NET constant
-    so the header bytes are byte-for-byte identical to the C# encoder; do not
-    "optimise" this to ``zlib.crc32`` — that would corrupt cross-SDK decoding.
+    This is exactly what :func:`zlib.crc32` computes (init/final ``0xFFFFFFFF``,
+    reflected), so we delegate to it — a C-speed call instead of a per-byte Python
+    loop, which was the dominant cost when writing dense-mesh bundles. The whole
+    stack (this encoder, the .NET ``SgeoEncoder``, the native nw/rvextract writers)
+    uses the standard polynomial so blobs stay byte-for-byte identical across
+    producers (content-hash dedup hashes the whole blob, header included).
     """
-    crc = 0xFFFFFFFF
-    for b in data:
-        crc = _CRC_TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
-    return crc ^ 0xFFFFFFFF
+    return zlib.crc32(data) & 0xFFFFFFFF
 
 
 # ── low-level body writers ─────────────────────────────────────────────────
@@ -126,6 +111,22 @@ def _f64(b: bytearray, v: float) -> None:
 def _i32(b: bytearray, v: int) -> None:
     # Low 32 bits, matching C# AddInt32's (byte)(v >> 8*i) over a 32-bit int.
     b += struct.pack("<I", v & 0xFFFFFFFF)
+
+
+def _f64_array(b: bytearray, vals) -> None:
+    """Pack a whole float sequence as little-endian f64 in one struct call."""
+    if vals:
+        b += struct.pack(f"<{len(vals)}d", *vals)
+
+
+def _i32_array(b: bytearray, vals) -> None:
+    """Pack a whole int sequence as low-32-bit LE words in one struct call.
+
+    Masked to 32 bits (unsigned ``I``) so packed ARGB colours (> int32 max) and mesh
+    face indices share one path, matching ``_i32``'s ``& 0xFFFFFFFF`` byte layout.
+    """
+    if vals:
+        b += struct.pack(f"<{len(vals)}I", *[v & 0xFFFFFFFF for v in vals])
 
 
 def _u32(b: bytearray, v: int) -> None:
@@ -205,22 +206,19 @@ def _encode_mesh(m) -> bytes:
     body = bytearray()
     _u32(body, len(m.vertices) // 3)
     _u32(body, len(m.faces))
-    for v in m.vertices:
-        _f64(body, v)
-    for f in m.faces:
-        _i32(body, f)
+    # Batched packs: one struct.pack per array (C-level) instead of one call per scalar —
+    # the per-double/-int loop was a hot spot on dense meshes. Byte layout is unchanged.
+    _f64_array(body, m.vertices)
+    _i32_array(body, m.faces)
     if has_normals:
         _pad8(body)
-        for n in m.vertexNormals:
-            _f64(body, n)
+        _f64_array(body, m.vertexNormals)
     if has_uvs:
         _pad8(body)
-        for t in m.textureCoordinates:
-            _f64(body, t)
+        _f64_array(body, m.textureCoordinates)
     if has_colors:
         # NB: no pad before colors — matches the C# encoder exactly.
-        for c in m.colors:
-            _i32(body, c)
+        _i32_array(body, m.colors)
 
     return _assemble(PrimitiveType.MESH, flags, m.units, body)
 

--- a/src/specklepy/bundle/spec/BUNDLE_SPEC_PIN.json
+++ b/src/specklepy/bundle/spec/BUNDLE_SPEC_PIN.json
@@ -1,0 +1,7 @@
+{
+  "name": "@speckle/bundle-spec",
+  "version": "5.0.0",
+  "schemaVersion": 5,
+  "specHash": "sha256:c4acd8053990ba8dfb49f1e848a56fe1b5596d695190fffcfd3ed6abe5139fd7",
+  "note": "Provenance of the vendored bundle_spec.py + bundle_schemas.py. Enforced by speckle-bundle-spec `npm run verify-pin -- --python <this dir>` (CI drift guard). Re-vendor: copy generated/python/*.py from the matching bundle-spec version + update this file."
+}

--- a/src/specklepy/bundle/spec/__init__.py
+++ b/src/specklepy/bundle/spec/__init__.py
@@ -1,0 +1,31 @@
+"""Vendored Speckle bundle spec — the single source of truth, generated.
+
+These two modules (``bundle_spec``, ``bundle_schemas``) are GENERATED from
+``speckle-bundle-spec/spec/bundle-spec.sql`` and committed here verbatim (the same
+"compiled-in" approach the .NET SDK uses with BundleSpec.cs / BundleSchemas.cs). Do
+not hand-edit. To refresh: in a sibling clone of ``speckle-bundle-spec`` run
+``node codegen/generate-all.mjs`` and copy ``generated/python/*.py`` over these files.
+"""
+
+from specklepy.bundle.spec.bundle_schemas import BY_TABLE, ColumnSpec
+from specklepy.bundle.spec.bundle_spec import (
+    NODE_KINDS,
+    REL_TYPES,
+    SCHEMA_VERSION,
+    NodeKind,
+    NodeKindRow,
+    Rel,
+    RelTypeRow,
+)
+
+__all__ = [
+    "BY_TABLE",
+    "ColumnSpec",
+    "NODE_KINDS",
+    "REL_TYPES",
+    "SCHEMA_VERSION",
+    "NodeKind",
+    "NodeKindRow",
+    "Rel",
+    "RelTypeRow",
+]

--- a/src/specklepy/bundle/spec/__init__.py
+++ b/src/specklepy/bundle/spec/__init__.py
@@ -3,8 +3,16 @@
 These two modules (``bundle_spec``, ``bundle_schemas``) are GENERATED from
 ``speckle-bundle-spec/spec/bundle-spec.sql`` and committed here verbatim (the same
 "compiled-in" approach the .NET SDK uses with BundleSpec.cs / BundleSchemas.cs). Do
-not hand-edit. To refresh: in a sibling clone of ``speckle-bundle-spec`` run
-``node codegen/generate-all.mjs`` and copy ``generated/python/*.py`` over these files.
+not hand-edit.
+
+PINNED: ``BUNDLE_SPEC_PIN.json`` records the exact bundle-spec version + spec hash these
+files were vendored from, so the C++ extractors (which build against the same published
+bundle-spec artifact) and this Python target stay in lockstep. CI enforces it with
+``npm run verify-pin -- --python <this dir>`` in the speckle-bundle-spec repo.
+
+To refresh: in a clone of ``speckle-bundle-spec`` at the target version run
+``node codegen/generate-all.mjs``, copy ``generated/python/*.py`` over these files, and
+update ``BUNDLE_SPEC_PIN.json`` (its ``version`` + ``specHash``).
 """
 
 from specklepy.bundle.spec.bundle_schemas import BY_TABLE, ColumnSpec

--- a/src/specklepy/bundle/spec/bundle_schemas.py
+++ b/src/specklepy/bundle/spec/bundle_schemas.py
@@ -1,0 +1,89 @@
+# GENERATED FROM spec/bundle-spec.sql — DO NOT EDIT.
+# Run `npm run generate` (or node codegen/generate-all.mjs) to refresh.
+"""Per-table parquet column descriptors (names, arrow type tokens, nullability).
+
+ArrowType is a string token ("int32" | "int64" | "string" | "float64" | "bool" |
+"binary"); the producer maps it to a pyarrow type once. Keeps this generated module
+dependency-free. Single source of truth: speckle-bundle-spec/spec/bundle-spec.sql.
+"""
+
+from typing import NamedTuple
+
+
+class ColumnSpec(NamedTuple):
+    name: str
+    type: str  # arrow type token; see module docstring
+    nullable: bool
+
+
+# table name -> ordered column descriptors (matches the parquet field order producers write).
+BY_TABLE: dict[str, list[ColumnSpec]] = {
+    "eav": [
+        ColumnSpec("object_index", "int32", False),
+        ColumnSpec("path_index", "int32", False),
+        ColumnSpec("value_string", "string", True),
+        ColumnSpec("value_double", "float64", True),
+        ColumnSpec("value_boolean", "bool", True),
+        ColumnSpec("unit", "string", True),
+        ColumnSpec("internal_definition_name", "string", True),
+    ],
+    "geometries": [
+        ColumnSpec("geometryIndex", "int32", False),
+        ColumnSpec("content", "binary", True),
+        ColumnSpec("id", "string", True),
+        ColumnSpec("type", "string", True),
+    ],
+    "nodes": [
+        ColumnSpec("id", "int32", False),
+        ColumnSpec("kind", "int32", False),
+        ColumnSpec("name", "string", True),
+        ColumnSpec("def_ref", "int32", True),
+        ColumnSpec("transform", "string", True),
+        ColumnSpec("units", "string", True),
+        ColumnSpec("subtype", "string", True),
+        ColumnSpec("argb", "int32", True),
+        ColumnSpec("opacity", "float64", True),
+        ColumnSpec("metalness", "float64", True),
+        ColumnSpec("roughness", "float64", True),
+        ColumnSpec("elevation", "float64", True),
+    ],
+    "object_type": [
+        ColumnSpec("object_index", "int32", False),
+        ColumnSpec("type_index", "int32", False),
+    ],
+    "objects": [
+        ColumnSpec("object_index", "int32", False),
+        ColumnSpec("application_id", "string", False),
+    ],
+    "paths": [
+        ColumnSpec("path_index", "int32", False),
+        ColumnSpec("path", "string", False),
+    ],
+    "relations": [
+        ColumnSpec("rel", "int32", False),
+        ColumnSpec("src", "int32", False),
+        ColumnSpec("dst", "int32", False),
+        ColumnSpec("ord", "int32", True),
+    ],
+    "scene_views": [
+        ColumnSpec("view", "int32", False),
+        ColumnSpec("name", "string", True),
+        ColumnSpec("is_default", "bool", True),
+        ColumnSpec("ord", "int32", True),
+        ColumnSpec("source", "string", True),
+        ColumnSpec("ref", "string", True),
+    ],
+    "type_eav": [
+        ColumnSpec("type_index", "int32", False),
+        ColumnSpec("path_index", "int32", False),
+        ColumnSpec("value_string", "string", True),
+        ColumnSpec("value_double", "float64", True),
+        ColumnSpec("value_boolean", "bool", True),
+        ColumnSpec("unit", "string", True),
+        ColumnSpec("internal_definition_name", "string", True),
+    ],
+    "types": [
+        ColumnSpec("type_index", "int32", False),
+        ColumnSpec("type_key", "string", False),
+    ],
+}

--- a/src/specklepy/bundle/spec/bundle_spec.py
+++ b/src/specklepy/bundle/spec/bundle_spec.py
@@ -1,0 +1,98 @@
+# GENERATED FROM spec/bundle-spec.sql — DO NOT EDIT.
+# Run `npm run generate` (or node codegen/generate-all.mjs) to refresh.
+"""Speckle bundle vocabulary (schema_version 5).
+
+Single source of truth: speckle-bundle-spec/spec/bundle-spec.sql. Regenerate with
+`node codegen/generate-all.mjs` in that repo, then re-vendor into specklepy.
+"""
+
+from enum import IntEnum
+from typing import NamedTuple, Optional
+
+SCHEMA_VERSION = 5
+
+
+class Rel(IntEnum):
+    """Live relation ids (typed envelope edges)."""
+
+    DISPLAY = 1
+    SOLID = 2
+    SUBELEMENT = 3
+    DEFINES = 4
+    HAS_MATERIAL = 5
+    HAS_COLOR = 6
+    ON_LEVEL = 7
+    DISPLAY_INSTANCE = 8
+    DEFINES_INSTANCE = 9
+    IN_COLLECTION = 10
+    IN_MODEL = 11
+    IN_ROOM = 12
+    IN_SYSTEM = 14
+    CONNECTS_TO = 21
+    BOUNDS = 23
+
+
+class NodeKind(IntEnum):
+    """Live node-kind ids (synthetic envelope nodes)."""
+
+    DEFINITION = 1
+    INSTANCE = 2
+    MATERIAL = 3
+    COLOR = 4
+    LEVEL = 5
+    CONTAINER = 7
+
+
+class RelTypeRow(NamedTuple):
+    id: int
+    name: str
+    src_ns: Optional[str]
+    dst_ns: Optional[str]
+    status: str
+    ord_semantics: Optional[str]
+
+
+class NodeKindRow(NamedTuple):
+    id: int
+    name: str
+    status: str
+    subtype_values: Optional[str]
+
+
+# Full catalogs incl. reserved/retired rows (ids are retired in place, never reused),
+# shipped in the bundle as the self-describing rel_types / node_kinds tables.
+REL_TYPES: list[RelTypeRow] = [
+    RelTypeRow(1, "DISPLAY", "object", "geometry", "live", "ordinal"),
+    RelTypeRow(2, "SOLID", "object", "geometry", "reserved", "ordinal"),
+    RelTypeRow(3, "SUBELEMENT", "object", "object", "live", "ordinal"),
+    RelTypeRow(4, "DEFINES", "node", "geometry", "live", None),
+    RelTypeRow(5, "HAS_MATERIAL", "geometry", "node", "live", None),
+    RelTypeRow(6, "HAS_COLOR", "geometry|object", "node", "live", None),
+    RelTypeRow(7, "ON_LEVEL", "object", "node", "live", None),
+    RelTypeRow(8, "DISPLAY_INSTANCE", "object", "node", "live", "ordinal"),
+    RelTypeRow(9, "DEFINES_INSTANCE", "node", "node", "live", "ordinal"),
+    RelTypeRow(10, "IN_COLLECTION", "object", "node", "live", None),
+    RelTypeRow(11, "IN_MODEL", "object", "node", "live", None),
+    RelTypeRow(12, "IN_ROOM", "object", "object", "live", None),
+    RelTypeRow(13, "IN_SPACE", None, None, "retired", None),
+    RelTypeRow(14, "IN_SYSTEM", "object", "node", "live", None),
+    RelTypeRow(15, "IN_NETWORK", None, None, "retired", None),
+    RelTypeRow(16, "IN_LINE", None, None, "retired", None),
+    RelTypeRow(17, "IN_GROUP", None, None, "retired", None),
+    RelTypeRow(18, "IN_ASSEMBLY", None, None, "retired", None),
+    RelTypeRow(19, "IN_SUBASSEMBLY", None, None, "retired", None),
+    RelTypeRow(20, "XREF", None, None, "retired", None),
+    RelTypeRow(21, "CONNECTS_TO", "object", "object", "live", "scope"),
+    RelTypeRow(22, "HOSTED_ON", None, None, "retired", None),
+    RelTypeRow(23, "BOUNDS", "object", "object", "live", None),
+]
+
+NODE_KINDS: list[NodeKindRow] = [
+    NodeKindRow(1, "DEFINITION", "live", None),
+    NodeKindRow(2, "INSTANCE", "live", None),
+    NodeKindRow(3, "MATERIAL", "live", None),
+    NodeKindRow(4, "COLOR", "live", None),
+    NodeKindRow(5, "LEVEL", "live", None),
+    NodeKindRow(6, "COLLECTION", "retired", None),
+    NodeKindRow(7, "CONTAINER", "live", "Collection,Model,MEP System,Network"),
+]

--- a/src/specklepy/bundle/upload.py
+++ b/src/specklepy/bundle/upload.py
@@ -27,8 +27,13 @@ class ArtifactUploadError(Exception):
 
 
 def _parse_etag(response: httpx.Response) -> str:
-    etag = response.headers.get("etag", "")
-    return etag.strip().strip('"')
+    # Return the ETag header VERBATIM — S3 wraps it in double quotes and the v2 complete
+    # endpoint compares the value against what S3 reports (quotes included). Stripping the
+    # quotes makes complete reject it ("Etag mismatch"). Matches .NET BlobApiHelpers.ParseEtagHeader.
+    etag = response.headers.get("etag")
+    if not etag:
+        raise ArtifactUploadError("S3 PUT response had no ETag header")
+    return etag
 
 
 class ArtifactPipeline:

--- a/src/specklepy/bundle/upload.py
+++ b/src/specklepy/bundle/upload.py
@@ -1,14 +1,15 @@
 """Speckle 4.0 artefact upload pipeline (server v2 data endpoints).
 
-Port of the .NET ``ArtifactPipeline``. Uploads a client-built artefact bundle (the parquet
-triple — geometries + eav.* + envelope.*) via the v2 endpoints: ``sign`` → presigned PUT
-per file → ``complete`` (which creates the version). Fully independent of the v1 send path.
+Port of the .NET ``ArtifactPipeline``. Uploads a client-built artefact bundle (the
+parquet triple — geometries + eav.* + envelope.*) via the v2 endpoints: ``sign`` →
+presigned PUT per file → ``complete`` (which creates the version). Fully independent
+of the v1 send path.
 
-The endpoints are **filename-keyed and count-agnostic**: ``sign`` takes the list of artefact
-basenames, the server presigns one PUT per name under ``versions/{versionId}/{name}``, and
-``complete`` verifies the etags and creates the commit with ``id = versionId``. The version
-id is **pre-allocated by the server at ingestion creation**, so artefact filenames can bake
-it in before any bytes exist.
+The endpoints are **filename-keyed and count-agnostic**: ``sign`` takes the list of
+artefact basenames, the server presigns one PUT per name under
+``versions/{versionId}/{name}``, and ``complete`` verifies the etags and creates the
+commit with ``id = versionId``. The version id is **pre-allocated by the server at
+ingestion creation**, so artefact filenames can bake it in before any bytes exist.
 """
 
 from __future__ import annotations
@@ -27,9 +28,10 @@ class ArtifactUploadError(Exception):
 
 
 def _parse_etag(response: httpx.Response) -> str:
-    # Return the ETag header VERBATIM — S3 wraps it in double quotes and the v2 complete
-    # endpoint compares the value against what S3 reports (quotes included). Stripping the
-    # quotes makes complete reject it ("Etag mismatch"). Matches .NET BlobApiHelpers.ParseEtagHeader.
+    # Return the ETag header VERBATIM — S3 wraps it in double quotes and the v2
+    # complete endpoint compares the value against what S3 reports (quotes included).
+    # Stripping the quotes makes complete reject it ("Etag mismatch"). Matches .NET
+    # BlobApiHelpers.ParseEtagHeader.
     etag = response.headers.get("etag")
     if not etag:
         raise ArtifactUploadError("S3 PUT response had no ETag header")
@@ -37,7 +39,7 @@ def _parse_etag(response: httpx.Response) -> str:
 
 
 class ArtifactPipeline:
-    """Uploads an already-built artefact bundle via the v2 sign → PUT → complete flow."""
+    """Uploads an already-built artefact bundle via v2 sign → PUT → complete flow."""
 
     def __init__(
         self,
@@ -65,7 +67,10 @@ class ArtifactPipeline:
         root_id: str,
         total_children_count: int,
     ) -> str:
-        """Upload a bundle (basename → local path) and complete the version. Returns the version id."""
+        """Upload a bundle (basename → local path) and complete the version.
+
+        Returns the version id.
+        """
         signed = self._sign(list(file_name_to_path.keys()))
         uploads = signed.get("uploads", {})
 
@@ -83,7 +88,7 @@ class ArtifactPipeline:
     def upload_dir(
         self, base_name: str, root_id: str, total_children_count: int
     ) -> str:
-        """Convenience: upload every ``{base_name}.*.parquet`` artefact in :attr:`output_dir`."""
+        """Upload every ``{base_name}.*.parquet`` artefact in :attr:`output_dir`."""
         files = {
             os.path.basename(p): p
             for p in sorted(
@@ -109,7 +114,10 @@ class ArtifactPipeline:
     # ── internals ──────────────────────────────────────────────────────────
 
     def _sign(self, files: list[str]) -> dict:
-        uri = f"projects/{self._project_id}/modelingestion/{self._ingestion_id}/uploads/sign"
+        uri = (
+            f"projects/{self._project_id}/modelingestion/{self._ingestion_id}"
+            "/uploads/sign"
+        )
         resp = self._speckle.post(uri, json={"files": files})
         self._ensure_success(resp, "artifacts sign")
         return resp.json()
@@ -126,7 +134,10 @@ class ArtifactPipeline:
     def _complete(
         self, etags: Mapping[str, str], root_id: str, total_children_count: int
     ) -> str:
-        uri = f"projects/{self._project_id}/modelingestion/{self._ingestion_id}/uploads/complete"
+        uri = (
+            f"projects/{self._project_id}/modelingestion/{self._ingestion_id}"
+            "/uploads/complete"
+        )
         resp = self._speckle.post(
             uri,
             json={
@@ -137,9 +148,10 @@ class ArtifactPipeline:
         )
         self._ensure_success(resp, "artifacts complete")
 
-        # The version id is pre-allocated (server-minted at ingestion creation) and is the commit
-        # PK the server just completed against — authoritative. If the server echoes a versionId it
-        # must match; a mismatch means we'd point at the wrong version, so fail loudly.
+        # The version id is pre-allocated (server-minted at ingestion creation) and is
+        # the commit PK the server just completed against — authoritative. If the server
+        # echoes a versionId it must match; a mismatch means we'd point at the wrong
+        # version, so fail loudly.
         echoed = None
         try:
             echoed = resp.json().get("versionId")
@@ -147,7 +159,8 @@ class ArtifactPipeline:
             echoed = None
         if echoed is not None and echoed != self.version_id:
             raise ArtifactUploadError(
-                f"Server completed version '{echoed}' but the pre-allocated id was '{self.version_id}'."
+                f"Server completed version '{echoed}' but the pre-allocated id was "
+                f"'{self.version_id}'."
             )
         return self.version_id
 

--- a/src/specklepy/bundle/upload.py
+++ b/src/specklepy/bundle/upload.py
@@ -1,0 +1,155 @@
+"""Speckle 4.0 artefact upload pipeline (server v2 data endpoints).
+
+Port of the .NET ``ArtifactPipeline``. Uploads a client-built artefact bundle (the parquet
+triple — geometries + eav.* + envelope.*) via the v2 endpoints: ``sign`` → presigned PUT
+per file → ``complete`` (which creates the version). Fully independent of the v1 send path.
+
+The endpoints are **filename-keyed and count-agnostic**: ``sign`` takes the list of artefact
+basenames, the server presigns one PUT per name under ``versions/{versionId}/{name}``, and
+``complete`` verifies the etags and creates the commit with ``id = versionId``. The version
+id is **pre-allocated by the server at ingestion creation**, so artefact filenames can bake
+it in before any bytes exist.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Mapping
+
+import httpx
+
+from specklepy.core.api.credentials import Account
+
+
+class ArtifactUploadError(Exception):
+    pass
+
+
+def _parse_etag(response: httpx.Response) -> str:
+    etag = response.headers.get("etag", "")
+    return etag.strip().strip('"')
+
+
+class ArtifactPipeline:
+    """Uploads an already-built artefact bundle via the v2 sign → PUT → complete flow."""
+
+    def __init__(
+        self,
+        project_id: str,
+        ingestion_id: str,
+        version_id: str,
+        account: Account,
+        output_dir: str,
+        timeout: float = 120.0,
+    ) -> None:
+        self._project_id = project_id
+        self._ingestion_id = ingestion_id
+        self.version_id = version_id
+        self.output_dir = output_dir
+
+        base = account.serverInfo.url.rstrip("/") + "/api/v2/"
+        headers = {"Authorization": f"Bearer {account.token}"} if account.token else {}
+        self._speckle = httpx.Client(base_url=base, headers=headers, timeout=timeout)
+        # presigned S3 PUTs are unauthenticated (the URL carries the signature).
+        self._s3 = httpx.Client(timeout=timeout)
+
+    def upload_files(
+        self,
+        file_name_to_path: Mapping[str, str],
+        root_id: str,
+        total_children_count: int,
+    ) -> str:
+        """Upload a bundle (basename → local path) and complete the version. Returns the version id."""
+        signed = self._sign(list(file_name_to_path.keys()))
+        uploads = signed.get("uploads", {})
+
+        etags: dict[str, str] = {}
+        for name, path in file_name_to_path.items():
+            presigned = uploads.get(name)
+            if presigned is None:
+                raise ArtifactUploadError(
+                    f"Server did not sign an upload for file '{name}'"
+                )
+            etags[name] = self._upload_file(path, presigned)
+
+        return self._complete(etags, root_id, total_children_count)
+
+    def upload_dir(
+        self, base_name: str, root_id: str, total_children_count: int
+    ) -> str:
+        """Convenience: upload every ``{base_name}.*.parquet`` artefact in :attr:`output_dir`."""
+        files = {
+            os.path.basename(p): p
+            for p in sorted(
+                glob.glob(os.path.join(self.output_dir, f"{base_name}.*.parquet"))
+            )
+        }
+        if not files:
+            raise ArtifactUploadError(
+                f"No artefact files found for base '{base_name}' in {self.output_dir}"
+            )
+        return self.upload_files(files, root_id, total_children_count)
+
+    def close(self) -> None:
+        self._speckle.close()
+        self._s3.close()
+
+    def __enter__(self) -> ArtifactPipeline:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ── internals ──────────────────────────────────────────────────────────
+
+    def _sign(self, files: list[str]) -> dict:
+        uri = f"projects/{self._project_id}/modelingestion/{self._ingestion_id}/uploads/sign"
+        resp = self._speckle.post(uri, json={"files": files})
+        self._ensure_success(resp, "artifacts sign")
+        return resp.json()
+
+    def _upload_file(self, file_path: str, presigned: Mapping) -> str:
+        url = presigned["url"]
+        extra = presigned.get("additionalRequestHeaders") or {}
+        headers = {"Content-Type": "application/octet-stream", **extra}
+        with open(file_path, "rb") as f:
+            resp = self._s3.put(url, content=f.read(), headers=headers)
+        resp.raise_for_status()
+        return _parse_etag(resp)
+
+    def _complete(
+        self, etags: Mapping[str, str], root_id: str, total_children_count: int
+    ) -> str:
+        uri = f"projects/{self._project_id}/modelingestion/{self._ingestion_id}/uploads/complete"
+        resp = self._speckle.post(
+            uri,
+            json={
+                "etags": dict(etags),
+                "rootId": root_id,
+                "totalChildrenCount": total_children_count,
+            },
+        )
+        self._ensure_success(resp, "artifacts complete")
+
+        # The version id is pre-allocated (server-minted at ingestion creation) and is the commit
+        # PK the server just completed against — authoritative. If the server echoes a versionId it
+        # must match; a mismatch means we'd point at the wrong version, so fail loudly.
+        echoed = None
+        try:
+            echoed = resp.json().get("versionId")
+        except Exception:  # noqa: BLE001 - body may legitimately be empty
+            echoed = None
+        if echoed is not None and echoed != self.version_id:
+            raise ArtifactUploadError(
+                f"Server completed version '{echoed}' but the pre-allocated id was '{self.version_id}'."
+            )
+        return self.version_id
+
+    @staticmethod
+    def _ensure_success(response: httpx.Response, operation: str) -> None:
+        if response.is_success:
+            return
+        raise ArtifactUploadError(
+            f"{operation} failed with {response.status_code}: {response.text}"
+        )

--- a/src/specklepy/core/api/models/current.py
+++ b/src/specklepy/core/api/models/current.py
@@ -266,3 +266,6 @@ class ModelIngestion(GraphQLBaseModel):
     user_id: str
     cancellation_requested: bool
     status_data: ModelIngestionStatusData
+    # Server pre-allocated version id (top-level field, populated at creation). The 4.0
+    # artefact bundle is uploaded under it. Null until selected by the query.
+    version_id: str | None = None

--- a/src/specklepy/core/api/models/current.py
+++ b/src/specklepy/core/api/models/current.py
@@ -266,6 +266,3 @@ class ModelIngestion(GraphQLBaseModel):
     user_id: str
     cancellation_requested: bool
     status_data: ModelIngestionStatusData
-    # Server pre-allocated version id (top-level field, populated at creation). The 4.0
-    # artefact bundle is uploaded under it. Null until selected by the query.
-    version_id: str | None = None

--- a/src/specklepy/core/api/resources/current/model_ingestion_resource.py
+++ b/src/specklepy/core/api/resources/current/model_ingestion_resource.py
@@ -53,7 +53,6 @@ class ModelIngestionResource(ResourceBase):
                   projectId
                   userId
                   cancellationRequested
-                  versionId
                   statusData {
                     ... on HasModelIngestionStatus {
                       status
@@ -97,7 +96,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -137,7 +135,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -175,7 +172,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -215,7 +211,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -299,7 +294,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -345,7 +339,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -398,7 +391,6 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
-                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status

--- a/src/specklepy/core/api/resources/current/model_ingestion_resource.py
+++ b/src/specklepy/core/api/resources/current/model_ingestion_resource.py
@@ -53,6 +53,7 @@ class ModelIngestionResource(ResourceBase):
                   projectId
                   userId
                   cancellationRequested
+                  versionId
                   statusData {
                     ... on HasModelIngestionStatus {
                       status
@@ -96,6 +97,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -135,6 +137,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -172,6 +175,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -211,6 +215,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -294,6 +299,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -339,6 +345,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status
@@ -391,6 +398,7 @@ class ModelIngestionResource(ResourceBase):
                     projectId
                     userId
                     cancellationRequested
+                    versionId
                     statusData {
                       ... on HasModelIngestionStatus {
                         status

--- a/src/specklepy/objects/proxies.py
+++ b/src/specklepy/objects/proxies.py
@@ -31,7 +31,6 @@ class GroupProxy(
 class SystemProxy(
     Base,
     speckle_type="Speckle.Core.Models.Proxies.SystemProxy",
-    detachable={"objects"},
 ):
     """
     Stores logical system (e.g. MEP distribution system) membership in root

--- a/src/specklepy/objects/proxies.py
+++ b/src/specklepy/objects/proxies.py
@@ -28,6 +28,64 @@ class GroupProxy(
 
 
 @dataclass(kw_only=True)
+class SystemProxy(
+    Base,
+    speckle_type="Speckle.Core.Models.Proxies.SystemProxy",
+    detachable={"objects"},
+):
+    """
+    Stores logical system (e.g. MEP distribution system) membership in root
+    collections. Sourced from IFC ``IfcSystem`` / ``IfcDistributionSystem``
+    grouping (``IfcRelAssignsToGroup``).
+
+    Args:
+        objects (list): application ids of the member elements
+        name (str): the system name (e.g. "S_Schmutzwasser")
+        applicationId (str): the IfcSystem GlobalId
+        systemType (str | None): predefined/object type, when present
+    """
+
+    objects: List[str]
+    name: str
+    applicationId: Optional[str]
+    systemType: Optional[str] = None
+
+
+@dataclass(kw_only=True)
+class ConnectionProxy(
+    Base,
+    speckle_type="Speckle.Core.Models.Proxies.ConnectionProxy",
+):
+    """
+    Stores a single network-connectivity edge between two elements, sourced
+    from IFC port connectivity (``IfcRelConnectsPorts`` resolved through the
+    ports' owning elements via ``IfcRelNests`` / ``IfcRelConnectsPortToElement``).
+
+    An edge is a directed pair with distinct endpoint roles, so the endpoints
+    are named fields rather than a positional ``objects`` list.
+
+    Args:
+        sourceAppId (str): application id of the source-end element
+            (owner of the relating port)
+        targetAppId (str): application id of the target-end element
+            (owner of the related port)
+        applicationId (str): the IfcRelConnectsPorts GlobalId
+        sourceFlowDirection (str | None): the source-end (relating) port's
+            FlowDirection (SOURCE / SINK / SOURCEANDSINK / NOTDEFINED)
+        targetFlowDirection (str | None): the target-end (related) port's
+            FlowDirection. Capturing both ends lets a consumer orient the edge
+            (SOURCE→SINK) where the data defines it; gravity systems remain
+            SOURCEANDSINK on both ends and stay undirected.
+    """
+
+    sourceAppId: str
+    targetAppId: str
+    applicationId: Optional[str]
+    sourceFlowDirection: Optional[str] = None
+    targetFlowDirection: Optional[str] = None
+
+
+@dataclass(kw_only=True)
 class InstanceProxy(
     Base,
     IHasUnits,

--- a/tests/bundle/test_eav_extraction.py
+++ b/tests/bundle/test_eav_extraction.py
@@ -1,0 +1,399 @@
+"""Tests for the EAV property extraction (behaviour-parity with the C# port)."""
+
+from __future__ import annotations
+
+from specklepy.bundle.eav_extraction import (
+    DEFAULT_EXCLUDED_TOP_LEVEL,
+    MAX_DEPTH,
+    REVIT_EXCLUDED_TOP_LEVEL,
+    ROOT_SCALAR_FIELDS,
+    EavRow,
+    flatten_object_properties,
+    flatten_properties,
+    flatten_subtree,
+    produces_rows,
+)
+
+
+def _by_path(rows: list[EavRow]) -> dict[str, EavRow]:
+    return {r.path: r for r in rows}
+
+
+# ───────────────────────────── nested dicts ────────────────────────────────
+
+
+def test_nested_dict_dotted_paths():
+    props = {
+        "Attributes": {"GlobalId": "abc"},
+        "Property Sets": {"Pset_WallCommon": {"IsExternal": True}},
+    }
+    rows = flatten_properties("obj1", props)
+    paths = _by_path(rows)
+
+    assert "properties.Attributes.GlobalId" in paths
+    assert "properties.Property Sets.Pset_WallCommon.IsExternal" in paths
+    assert paths["properties.Attributes.GlobalId"].object_id == "obj1"
+
+
+def test_deeply_nested_paths_joined_with_dots():
+    props = {"a": {"b": {"c": {"d": 5}}}}
+    rows = flatten_properties("o", props)
+    assert _by_path(rows)["properties.a.b.c.d"].value_num == 5.0
+
+
+# ───────────────────────────── typing ──────────────────────────────────────
+
+
+def test_number_boolean_string_typing():
+    props = {"num": 42, "flt": 3.5, "flag": True, "text": "hello"}
+    rows = _by_path(flatten_properties("o", props))
+
+    assert rows["properties.num"].type == "number"
+    assert rows["properties.num"].value_num == 42.0
+    assert rows["properties.num"].value_text == "42"
+
+    assert rows["properties.flt"].type == "number"
+    assert rows["properties.flt"].value_num == 3.5
+
+    assert rows["properties.flag"].type == "boolean"
+    assert rows["properties.flag"].value_num is None
+    assert rows["properties.flag"].value_text == "true"
+
+    assert rows["properties.text"].type == "string"
+    assert rows["properties.text"].value_num is None
+    assert rows["properties.text"].value_text == "hello"
+
+
+def test_integral_float_text_drops_trailing_zero():
+    # JS String(1.0) === "1" / C# "R" format (EavExtraction.cs:790).
+    rows = _by_path(flatten_properties("o", {"x": 1.0}))
+    assert rows["properties.x"].value_text == "1"
+    assert rows["properties.x"].value_num == 1.0
+
+
+def test_string_true_false_infer_boolean():
+    rows = _by_path(flatten_properties("o", {"a": "true", "b": "FALSE"}))
+    assert rows["properties.a"].type == "boolean"
+    assert rows["properties.b"].type == "boolean"
+    # value_text stays verbatim (not normalised).
+    assert rows["properties.a"].value_text == "true"
+    assert rows["properties.b"].value_text == "FALSE"
+
+
+# ───────────────────── numeric-string inference + UUID ──────────────────────
+
+
+def test_numeric_string_inference():
+    rows = _by_path(flatten_properties("o", {"a": "3.14", "b": " 42 ", "c": "1e3"}))
+    assert rows["properties.a"].type == "number"
+    assert rows["properties.a"].value_num == 3.14
+    assert rows["properties.a"].value_text == "3.14"  # verbatim
+
+    assert rows["properties.b"].type == "number"
+    assert rows["properties.b"].value_num == 42.0
+
+    assert rows["properties.c"].type == "number"
+    assert rows["properties.c"].value_num == 1000.0
+
+
+def test_uuid_like_string_rejected_from_number():
+    rows = _by_path(flatten_properties("o", {"guid": "1-2-3", "g2": "a-b-c-d"}))
+    assert rows["properties.guid"].type == "string"
+    assert rows["properties.guid"].value_num is None
+    assert rows["properties.g2"].type == "string"
+
+
+def test_empty_and_whitespace_string_is_string():
+    rows = _by_path(flatten_properties("o", {"a": "", "b": "   "}))
+    assert rows["properties.a"].type == "string"
+    assert rows["properties.b"].type == "string"
+
+
+def test_non_finite_string_rejected():
+    # "inf"/"nan" parse but fail the IsFinite guard → string.
+    rows = _by_path(flatten_properties("o", {"a": "inf", "b": "nan"}))
+    assert rows["properties.a"].type == "string"
+    assert rows["properties.b"].type == "string"
+
+
+def test_underscore_grouping_rejected():
+    # Python float("1_000") == 1000 but C# NumberStyles.Float rejects it.
+    rows = _by_path(flatten_properties("o", {"a": "1_000"}))
+    assert rows["properties.a"].type == "string"
+
+
+# ───────────────────────────── exclusions ──────────────────────────────────
+
+
+def test_excluded_top_level_skipped_entirely():
+    props = {
+        "Autodesk Material": {"deep": {"x": 1}},
+        "Document": {"y": 2},
+        "Keep": {"z": 3},
+    }
+    rows = flatten_properties("o", props, excluded_top_level=DEFAULT_EXCLUDED_TOP_LEVEL)
+    paths = {r.path for r in rows}
+
+    assert not any(p.startswith("properties.Autodesk Material") for p in paths)
+    assert not any(p.startswith("properties.Document") for p in paths)
+    assert "properties.Keep.z" in paths
+
+
+def test_exclusions_apply_at_top_level_only():
+    # A nested "Document" key (not top-level) must NOT be excluded.
+    props = {"Group": {"Document": {"x": 1}}}
+    rows = flatten_properties("o", props, excluded_top_level=DEFAULT_EXCLUDED_TOP_LEVEL)
+    assert "properties.Group.Document.x" in {r.path for r in rows}
+
+
+def test_no_exclusions_by_default():
+    props = {"Autodesk Material": {"x": 1}}
+    rows = flatten_properties("o", props)
+    assert "properties.Autodesk Material.x" in {r.path for r in rows}
+
+
+# ───────────────────────────── MAX_DEPTH ───────────────────────────────────
+
+
+def test_max_depth_cutoff():
+    # Build properties.l0.l1...; depth counter starts at 0 for the contents of
+    # `properties`, so a leaf is emitted only while depth < MAX_DEPTH.
+    leaf: dict = {"leaf": 1}
+    node: dict = leaf
+    for _ in range(MAX_DEPTH + 3):
+        node = {"n": node}
+    rows = flatten_properties("o", node)
+    # No row should have a path deeper than MAX_DEPTH segments under properties.
+    for r in rows:
+        segments = r.path.split(".")
+        # "properties" + at most MAX_DEPTH levels
+        assert len(segments) <= MAX_DEPTH + 1
+
+
+def test_max_depth_emits_shallow_leaf():
+    rows = flatten_properties("o", {"a": {"b": 1}})
+    assert "properties.a.b" in {r.path for r in rows}
+
+
+# ───────────────────────────── root scalars ────────────────────────────────
+
+
+def test_root_scalars_emitted_from_mapping():
+    scalars = {
+        "name": "Wall",
+        "applicationId": "guid-1",
+        "speckle_type": "Objects.Data.DataObject",
+    }
+    rows = flatten_properties("o", {}, root_scalars=scalars)
+    paths = _by_path(rows)
+    assert paths["name"].value_text == "Wall"
+    assert paths["name"].object_id == "o"
+    assert "applicationId" in paths
+    assert "speckle_type" in paths
+
+
+def test_root_scalars_from_iterable_of_pairs():
+    rows = flatten_properties("o", {}, root_scalars=[("name", "X"), ("level", 2)])
+    paths = _by_path(rows)
+    assert paths["name"].value_text == "X"
+    assert paths["level"].type == "number"
+
+
+def test_root_scalars_skip_non_scalar():
+    rows = flatten_properties(
+        "o", {}, root_scalars={"name": "X", "obj": {"a": 1}, "arr": [1, 2]}
+    )
+    paths = {r.path for r in rows}
+    assert "name" in paths
+    assert "obj" not in paths
+    assert "arr" not in paths
+
+
+# ───────────────────────────── parameter pattern ───────────────────────────
+
+
+def test_parameter_pattern_name_value_units():
+    props = {
+        "Dimensions": {
+            "Width": {
+                "name": "Width",
+                "value": 200.0,
+                "units": "mm",
+                "internalDefinitionName": "WIDTH",
+            },
+        }
+    }
+    rows = _by_path(flatten_properties("o", props))
+    row = rows["properties.Dimensions.Width"]
+    assert row.type == "number"
+    assert row.value_num == 200.0
+    assert row.units == "mm"
+    assert row.internal_definition_name == "WIDTH"
+
+
+def test_parameter_with_object_value_skipped():
+    props = {"P": {"name": "P", "value": {"nested": 1}}}
+    rows = flatten_properties("o", props)
+    assert rows == []
+
+
+# ───────────────────────────── lists skipped ───────────────────────────────
+
+
+def test_lists_are_skipped():
+    props = {"arr": [1, 2, 3], "keep": 5}
+    rows = _by_path(flatten_properties("o", props))
+    assert "properties.arr" not in rows
+    assert "properties.keep" in rows
+
+
+def test_none_values_skipped():
+    rows = flatten_properties("o", {"a": None, "b": 1})
+    assert {r.path for r in rows} == {"properties.b"}
+
+
+# ───────────────────────────── material quantities ─────────────────────────
+
+
+def test_material_quantities_extraction():
+    props = {
+        "Material Quantities": {
+            "Concrete": {
+                "materialCategory": "Structural",
+                "area": {"value": 12.5, "units": "m2"},
+                "volume": {"value": 3.0, "units": "m3"},
+            }
+        }
+    }
+    rows = _by_path(flatten_properties("o", props))
+    area = rows["properties.Material Quantities.Structural.Concrete.area"]
+    vol = rows["properties.Material Quantities.Structural.Concrete.volume"]
+    assert area.value_num == 12.5
+    assert area.units == "m2"
+    assert vol.value_num == 3.0
+    # The walk itself must NOT emit raw Material Quantities rows.
+    assert not any(p.endswith(".materialCategory") for p in rows)
+
+
+# ───────────────────────────── flatten_subtree ─────────────────────────────
+
+
+def test_flatten_subtree_empty_object_id_and_prefix():
+    rows = flatten_subtree({"Width": {"name": "Width", "value": 5}}, "type.Parameters")
+    assert len(rows) == 1
+    assert rows[0].path == "type.Parameters.Width"
+    assert rows[0].object_id == ""
+
+
+# ───────────────────────────── dispatcher ──────────────────────────────────
+
+
+def test_flatten_object_properties_data_object():
+    obj = {
+        "speckle_type": "Objects.Data.DataObject",
+        "name": "Wall",
+        "applicationId": "guid",
+        "properties": {"Pset": {"A": 1}},
+    }
+    rows = _by_path(flatten_object_properties("o", obj))
+    assert rows["name"].value_text == "Wall"
+    assert rows["applicationId"].value_text == "guid"
+    assert rows["properties.Pset.A"].value_num == 1.0
+
+
+def test_flatten_object_properties_missing_type_is_data_object():
+    rows = flatten_object_properties("o", {"name": "X", "properties": {"a": 1}})
+    assert "properties.a" in {r.path for r in rows}
+
+
+def test_flatten_object_properties_instance_proxy_transform():
+    transform = [
+        1,
+        0,
+        0,
+        10,
+        0,
+        1,
+        0,
+        20,
+        0,
+        0,
+        1,
+        30,
+        0,
+        0,
+        0,
+        1,
+    ]
+    obj = {
+        "speckle_type": "Speckle.Core.Models.Instances.InstanceProxy",
+        "units": "mm",
+        "transform": transform,
+    }
+    rows = _by_path(flatten_object_properties("o", obj))
+    assert rows["proxy.transform.tx"].value_num == 10.0
+    assert rows["proxy.transform.ty"].value_num == 20.0
+    assert rows["proxy.transform.tz"].value_num == 30.0
+    assert rows["proxy.transform.tx"].units == "mm"
+    assert "proxy.transform.matrix" in rows
+
+
+def test_flatten_object_properties_collection_elements():
+    obj = {
+        "speckle_type": "Speckle.Core.Models.Collection",
+        "name": "Layer",
+        "elements": [{"referencedId": "id1"}, {"id": "id2"}, {"speckle_type": "x"}],
+    }
+    rows = _by_path(flatten_object_properties("o", obj))
+    assert rows["name"].value_text == "Layer"
+    assert rows["elements"].value_text == '["id1","id2"]'
+
+
+def test_flatten_object_properties_geometry_returns_nothing():
+    assert (
+        flatten_object_properties("o", {"speckle_type": "Objects.Geometry.Mesh"}) == []
+    )
+
+
+def test_display_value_refs():
+    obj = {
+        "speckle_type": "Objects.Data.DataObject",
+        "displayValue": [
+            {"referencedId": "ref0"},
+            {"id": "inl1"},
+            {"speckle_type": "x"},
+        ],
+    }
+    rows = _by_path(flatten_object_properties("o", obj))
+    assert rows["displayValue.0.referencedId"].value_text == "ref0"
+    assert rows["displayValue.1.referencedId"].value_text == "inl1"
+    assert "displayValue.2.referencedId" not in rows
+
+
+def test_location_extraction():
+    obj = {
+        "speckle_type": "Objects.Data.DataObject",
+        "location": {"x": 1.0, "y": 2.0, "z": 3.0, "units": "m"},
+    }
+    rows = _by_path(flatten_object_properties("o", obj))
+    assert rows["location.x"].value_num == 1.0
+    assert rows["location.z"].units == "m"
+
+
+def test_produces_rows():
+    assert produces_rows("")
+    assert produces_rows("Objects.Data.DataObject")
+    assert produces_rows("Some.InstanceProxy")
+    assert produces_rows("My.Collection")
+    assert produces_rows("Some.Layer")
+    assert not produces_rows("Objects.Geometry.Mesh")
+
+
+# ───────────────────────────── constants ───────────────────────────────────
+
+
+def test_constants_match_contract():
+    assert frozenset({"Autodesk Material", "Document"}) == DEFAULT_EXCLUDED_TOP_LEVEL
+    assert "Phase Created" in REVIT_EXCLUDED_TOP_LEVEL
+    assert ROOT_SCALAR_FIELDS[0] == "name"
+    assert "ifcType" in ROOT_SCALAR_FIELDS

--- a/tests/bundle/test_ifc_exporter.py
+++ b/tests/bundle/test_ifc_exporter.py
@@ -1,6 +1,6 @@
-"""IfcBundleExporter on a synthetic converted tree — exercises the proxy→envelope mapping,
-especially the topology branches the real sample files don't cover (directed CONNECTS_TO,
-IN_SYSTEM)."""
+"""IfcBundleExporter on a synthetic converted tree — exercises the proxy→envelope
+mapping, especially the topology branches the real sample files don't cover
+(directed CONNECTS_TO, IN_SYSTEM)."""
 
 from __future__ import annotations
 
@@ -111,7 +111,8 @@ def test_exporter_maps_full_tree(tmp_path):
 
     def k_of(app_id):
         return con.execute(
-            f"SELECT object_index FROM {g}.eav.objects.parquet') WHERE application_id = ?",
+            f"SELECT object_index FROM {g}.eav.objects.parquet') "
+            "WHERE application_id = ?",
             [app_id],
         ).fetchone()[0]
 
@@ -137,7 +138,8 @@ def test_exporter_maps_full_tree(tmp_path):
 
     # system container: subtype canonical "System", IFC type folded into name
     sysrow = con.execute(
-        f"SELECT name, subtype FROM {g}.envelope.nodes.parquet') WHERE subtype = 'System'"
+        f"SELECT name, subtype FROM {g}.envelope.nodes.parquet') "
+        "WHERE subtype = 'System'"
     ).fetchone()
     assert sysrow[1] == "System"
     assert "AIRCONDITIONING" in sysrow[0]
@@ -160,7 +162,8 @@ def test_exporter_maps_full_tree(tmp_path):
     ).fetchone()[0]
     assert argb == 0xFFAABBCC - 0x1_0000_0000
 
-    # default scene view is Level (ON_LEVEL rel) > IFC class (ifcType eav), outermost-first
+    # default scene view is Level (ON_LEVEL rel) > IFC class (ifcType eav),
+    # outermost-first
     sv = con.execute(
         f"SELECT ord, source, ref FROM {g}.envelope.scene_views.parquet') "
         "WHERE is_default ORDER BY view, ord"

--- a/tests/bundle/test_ifc_exporter.py
+++ b/tests/bundle/test_ifc_exporter.py
@@ -1,0 +1,161 @@
+"""IfcBundleExporter on a synthetic converted tree — exercises the proxy→envelope mapping,
+especially the topology branches the real sample files don't cover (directed CONNECTS_TO,
+IN_SYSTEM)."""
+
+from __future__ import annotations
+
+import duckdb
+
+from speckleifc.bundle_exporter import IfcBundleExporter
+from specklepy.bundle.spec import Rel
+from specklepy.objects.data_objects import DataObject
+from specklepy.objects.geometry.mesh import Mesh
+from specklepy.objects.models.collections.collection import Collection
+from specklepy.objects.other import RenderMaterial
+from specklepy.objects.proxies import (
+    ConnectionProxy,
+    InstanceDefinitionProxy,
+    InstanceProxy,
+    LevelProxy,
+    RenderMaterialProxy,
+    SystemProxy,
+)
+
+BASE = "syn"
+
+
+def _build_tree() -> Collection:
+    mesh = Mesh(vertices=[0, 0, 0, 1, 0, 0, 0, 1, 0], faces=[3, 0, 1, 2], units="m")
+    mesh.applicationId = "mesh-1"
+
+    wall = DataObject(
+        applicationId="wall-guid",
+        name="Wall",
+        properties={"Pset": {"Width": 200}},
+        displayValue=[
+            InstanceProxy(
+                units="m",
+                definitionId="DEFINITION:mesh-1",
+                transform=[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                maxDepth=0,
+                applicationId="wall:DEF",
+            )
+        ],
+    )
+    wall["ifcType"] = "IfcWall"
+    wall["@elements"] = []
+
+    root = Collection(applicationId="proj", name="Project", elements=[wall])
+    root["ifcType"] = "IfcProject"
+    root.elements.append(Collection(name="definitionGeometry", elements=[mesh]))
+
+    root["instanceDefinitionProxies"] = [
+        InstanceDefinitionProxy(
+            applicationId="DEFINITION:mesh-1",
+            name="def",
+            objects=["mesh-1"],
+            maxDepth=0,
+        )
+    ]
+    root["renderMaterialProxies"] = [
+        RenderMaterialProxy(
+            objects=["mesh-1"],
+            value=RenderMaterial(
+                applicationId="mat-1", name="Steel", diffuse=0xFFAABBCC, opacity=1.0
+            ),
+        )
+    ]
+    level = DataObject(
+        applicationId="L1",
+        name="Level 1",
+        properties={"Attributes": {"Elevation": 3.0}},
+        displayValue=[],
+    )
+    root["levelProxies"] = [
+        LevelProxy(objects=["wall-guid"], value=level, applicationId="L1")
+    ]
+    root["systemProxies"] = [
+        SystemProxy(
+            objects=["wall-guid"],
+            name="HVAC",
+            applicationId="sys-1",
+            systemType="AIRCONDITIONING",
+        )
+    ]
+    root["connectionProxies"] = [
+        ConnectionProxy(
+            sourceAppId="a",
+            targetAppId="b",
+            applicationId="c1",
+            sourceFlowDirection="SOURCE",
+            targetFlowDirection="SINK",
+        ),
+        ConnectionProxy(
+            sourceAppId="x",
+            targetAppId="y",
+            applicationId="c2",
+            sourceFlowDirection="SOURCEANDSINK",
+            targetFlowDirection="SOURCEANDSINK",
+        ),
+    ]
+    return root
+
+
+def test_exporter_maps_full_tree(tmp_path):
+    out = str(tmp_path)
+    root_id, obj_count = IfcBundleExporter(out, BASE).export(_build_tree())
+    assert root_id == "proj"
+
+    con = duckdb.connect()
+    g = f"read_parquet('{out}/{BASE}"
+
+    def k_of(app_id):
+        return con.execute(
+            f"SELECT object_index FROM {g}.eav.objects.parquet') WHERE application_id = ?",
+            [app_id],
+        ).fetchone()[0]
+
+    rels = set(
+        con.execute(
+            f"SELECT rel, src, dst FROM {g}.envelope.relations.parquet')"
+        ).fetchall()
+    )
+
+    # geometry + definition + material wiring
+    assert (
+        con.execute(f"SELECT count(*) FROM {g}.geometries.parquet')").fetchone()[0] == 1
+    )
+    assert any(r[0] == int(Rel.DEFINES) for r in rels)
+    assert any(r[0] == int(Rel.HAS_MATERIAL) for r in rels)
+    assert any(r[0] == int(Rel.DISPLAY_INSTANCE) for r in rels)
+
+    # wall is IN_COLLECTION of the project; ON_LEVEL L1; IN_SYSTEM sys-1
+    wall_k = k_of("wall-guid")
+    assert any(r[0] == int(Rel.IN_COLLECTION) and r[1] == wall_k for r in rels)
+    assert any(r[0] == int(Rel.ON_LEVEL) and r[1] == wall_k for r in rels)
+    assert any(r[0] == int(Rel.IN_SYSTEM) and r[1] == wall_k for r in rels)
+
+    # system container: subtype canonical "System", IFC type folded into name
+    sysrow = con.execute(
+        f"SELECT name, subtype FROM {g}.envelope.nodes.parquet') WHERE subtype = 'System'"
+    ).fetchone()
+    assert sysrow[1] == "System"
+    assert "AIRCONDITIONING" in sysrow[0]
+
+    # directed connection a->b is a SINGLE edge; undirected x<->y is a reciprocal pair
+    a, b, x, y = k_of("a"), k_of("b"), k_of("x"), k_of("y")
+    assert (int(Rel.CONNECTS_TO), a, b) in rels
+    assert (int(Rel.CONNECTS_TO), b, a) not in rels
+    assert (int(Rel.CONNECTS_TO), x, y) in rels and (int(Rel.CONNECTS_TO), y, x) in rels
+
+    # level node carries elevation
+    elev = con.execute(
+        f"SELECT elevation FROM {g}.envelope.nodes.parquet') WHERE kind = 5"
+    ).fetchone()[0]
+    assert elev == 3.0
+
+    # ARGB stored as signed int32 (0xFFAABBCC -> negative)
+    argb = con.execute(
+        f"SELECT argb FROM {g}.envelope.nodes.parquet') WHERE kind = 3"
+    ).fetchone()[0]
+    assert argb == 0xFFAABBCC - 0x1_0000_0000

--- a/tests/bundle/test_ifc_exporter.py
+++ b/tests/bundle/test_ifc_exporter.py
@@ -159,3 +159,10 @@ def test_exporter_maps_full_tree(tmp_path):
         f"SELECT argb FROM {g}.envelope.nodes.parquet') WHERE kind = 3"
     ).fetchone()[0]
     assert argb == 0xFFAABBCC - 0x1_0000_0000
+
+    # default scene view is Level (ON_LEVEL rel) > IFC class (ifcType eav), outermost-first
+    sv = con.execute(
+        f"SELECT ord, source, ref FROM {g}.envelope.scene_views.parquet') "
+        "WHERE is_default ORDER BY view, ord"
+    ).fetchall()
+    assert sv == [(0, "rel", str(int(Rel.ON_LEVEL))), (1, "eav", "ifcType")]

--- a/tests/bundle/test_pipeline.py
+++ b/tests/bundle/test_pipeline.py
@@ -1,0 +1,96 @@
+"""End-to-end: drive ObjectsArtifactPipeline with a real Mesh + nodes/relations/props,
+then read the whole bundle back with DuckDB."""
+
+from __future__ import annotations
+
+import duckdb
+
+from specklepy.bundle.pipeline import ObjectsArtifactPipeline
+from specklepy.bundle.spec import Rel
+from specklepy.objects.geometry.mesh import Mesh
+
+BASE = "model"
+
+
+def _mesh() -> Mesh:
+    # a single triangle
+    return Mesh(
+        vertices=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        faces=[3, 0, 1, 2],
+        units="m",
+    )
+
+
+def test_pipeline_full_bundle(tmp_path):
+    out = str(tmp_path)
+    with ObjectsArtifactPipeline(out, BASE) as p:
+        obj_k = p.intern_object("element-1")
+        p.add_properties(
+            "element-1",
+            {"Pset_Wall": {"Width": 200}},
+            root_scalars=[("name", "Wall-1"), ("ifcType", "IfcWall")],
+        )
+
+        # definition holds the mesh; instance places it; object displays the instance.
+        geo_k = p.add_geometry("mesh-1", _mesh())
+        def_k = p.add_definition("def-1", "WallBody")
+        p.defines(def_k, geo_k, 0)
+        inst_k = p.add_instance(
+            "place-1", def_k, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], "m"
+        )
+        p.display_instance(obj_k, inst_k, 0)
+
+        mat_k = p.add_material(
+            "mat-1", argb=-1, opacity=1.0, metalness=0.0, roughness=0.5
+        )
+        p.has_material(geo_k, mat_k)
+
+        sys_k = p.add_container("sys-1", "Hot Water", None, "System")
+        p.in_system(obj_k, sys_k, 0)
+        p.connects_to(obj_k, obj_k)  # trivial self-edge just to exercise the rel
+
+    con = duckdb.connect()
+    g = f"read_parquet('{out}/{BASE}"
+
+    # geometry landed with SGEO content + sha256 id
+    geo = con.execute(
+        f"SELECT geometryIndex, octet_length(content), type FROM {g}.geometries.parquet')"
+    ).fetchall()
+    assert geo == [(geo_k, geo[0][1], "mesh")]
+    assert geo[0][1] >= 16  # at least the SGEO header
+
+    # the eav side has the object + its width + root scalars
+    width = con.execute(
+        f"""SELECT e.value_double FROM {g}.eav.eav.parquet') e
+            JOIN {g}.eav.paths.parquet') pa USING(path_index)
+            WHERE pa.path = 'properties.Pset_Wall.Width'"""
+    ).fetchone()
+    assert width[0] == 200.0
+    names = con.execute(
+        f"""SELECT e.value_string FROM {g}.eav.eav.parquet') e
+            JOIN {g}.eav.paths.parquet') pa USING(path_index)
+            WHERE pa.path = 'ifcType'"""
+    ).fetchone()
+    assert names[0] == "IfcWall"
+
+    # envelope: the edges we emitted are present, with the right rel ids
+    rels = set(
+        con.execute(
+            f"SELECT rel, src, dst FROM {g}.envelope.relations.parquet')"
+        ).fetchall()
+    )
+    assert (int(Rel.DEFINES), def_k, geo_k) in rels
+    assert (int(Rel.DISPLAY_INSTANCE), obj_k, inst_k) in rels
+    assert (int(Rel.HAS_MATERIAL), geo_k, mat_k) in rels
+    assert (int(Rel.IN_SYSTEM), obj_k, sys_k) in rels
+    assert (int(Rel.CONNECTS_TO), obj_k, obj_k) in rels
+
+    # the instance node carries its transform + units; the system container its subtype
+    inst = con.execute(
+        f"SELECT transform, units FROM {g}.envelope.nodes.parquet') WHERE id = {inst_k}"
+    ).fetchone()
+    assert inst[1] == "m" and inst[0].startswith("1.0,0.0")
+    sub = con.execute(
+        f"SELECT subtype, name FROM {g}.envelope.nodes.parquet') WHERE id = {sys_k}"
+    ).fetchone()
+    assert sub == ("System", "Hot Water")

--- a/tests/bundle/test_pipeline.py
+++ b/tests/bundle/test_pipeline.py
@@ -54,7 +54,8 @@ def test_pipeline_full_bundle(tmp_path):
 
     # geometry landed with SGEO content + sha256 id
     geo = con.execute(
-        f"SELECT geometryIndex, octet_length(content), type FROM {g}.geometries.parquet')"
+        f"SELECT geometryIndex, octet_length(content), type "
+        f"FROM {g}.geometries.parquet')"
     ).fetchall()
     assert geo == [(geo_k, geo[0][1], "mesh")]
     assert geo[0][1] >= 16  # at least the SGEO header

--- a/tests/bundle/test_sgeo.py
+++ b/tests/bundle/test_sgeo.py
@@ -1,0 +1,204 @@
+import struct
+
+import pytest
+
+from specklepy.bundle import sgeo
+from specklepy.objects.geometry.mesh import Mesh
+
+
+def _make_mesh(**kwargs) -> Mesh:
+    defaults = dict(
+        vertices=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        faces=[3, 0, 1, 2],
+        units="m",
+    )
+    defaults.update(kwargs)
+    return Mesh(**defaults)
+
+
+def _reference_crc32(data: bytes, poly: int) -> int:
+    """Independent table-free CRC32 reference, parameterised by polynomial."""
+    crc = 0xFFFFFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (poly ^ (crc >> 1)) if (crc & 1) else (crc >> 1)
+    return crc ^ 0xFFFFFFFF
+
+
+def test_crc32_matches_dotnet_polynomial():
+    # SgeoFormat.cs uses the constant 0xEDB88820 (NOT the canonical IEEE
+    # 0xEDB88320). We replicate it for byte-for-byte parity with the .NET
+    # encoder, so sgeo.crc32 must match a bit-by-bit reference using 0xEDB88820.
+    samples = [
+        b"",
+        b"SGEO",
+        b"the quick brown fox",
+        bytes(range(256)),
+        b"\x00\x01\x02\x03\xff\xfe\xfd",
+    ]
+    for s in samples:
+        assert sgeo.crc32(s) == _reference_crc32(s, 0xEDB88820)
+
+
+def test_crc32_differs_from_zlib_due_to_nonstandard_poly():
+    # Document the gotcha: SGEO's CRC is NOT standard CRC-32, so it must not be
+    # swapped for zlib.crc32. zlib equals the canonical 0xEDB88320 reference.
+    import zlib
+
+    s = b"the quick brown fox"
+    assert sgeo.crc32(s) == _reference_crc32(s, 0xEDB88820)
+    assert (zlib.crc32(s) & 0xFFFFFFFF) == _reference_crc32(s, 0xEDB88320)
+    assert sgeo.crc32(s) != (zlib.crc32(s) & 0xFFFFFFFF)
+
+
+def test_unit_encoding_mapping():
+    assert sgeo.get_encoding_from_unit("mm") == 1
+    assert sgeo.get_encoding_from_unit("cm") == 2
+    assert sgeo.get_encoding_from_unit("m") == 3
+    assert sgeo.get_encoding_from_unit("km") == 4
+    assert sgeo.get_encoding_from_unit("in") == 5
+    assert sgeo.get_encoding_from_unit("ft") == 6
+    assert sgeo.get_encoding_from_unit("yd") == 7
+    assert sgeo.get_encoding_from_unit("mi") == 8
+    # unknown / aliases / none silently map to 0 (matches C# GetEncodingFromUnit)
+    assert sgeo.get_encoding_from_unit("none") == 0
+    assert sgeo.get_encoding_from_unit("millimeters") == 0
+    assert sgeo.get_encoding_from_unit(None) == 0
+
+
+def test_try_get_primitive_type():
+    assert sgeo.try_get_primitive_type(_make_mesh()) == 0
+    assert sgeo.try_get_primitive_type(object()) is None
+
+
+def test_mesh_header_bytes():
+    mesh = _make_mesh(units="mm")
+    blob = sgeo.encode(mesh)
+
+    # magic, version, primitive type
+    assert blob[0:4] == b"SGEO"
+    assert blob[4] == sgeo.VERSION_1 == 1
+    assert blob[5] == int(sgeo.PrimitiveType.MESH) == 0
+
+    # flags (no normals/uvs/colors) == 0
+    flags = struct.unpack_from("<H", blob, 6)[0]
+    assert flags == 0
+
+    # units code for "mm" == 1
+    units_code = struct.unpack_from("<H", blob, 8)[0]
+    assert units_code == 1
+
+    # reserved == 0
+    assert struct.unpack_from("<H", blob, 10)[0] == 0
+
+    # body starts at 0x10, header is 16 bytes
+    assert sgeo.HEADER_SIZE == 16
+    body = blob[sgeo.HEADER_SIZE :]
+
+    # crc matches recomputation over the body bytes only
+    stored_crc = struct.unpack_from("<I", blob, 12)[0]
+    assert stored_crc == sgeo.crc32(body)
+
+
+def test_mesh_body_layout():
+    vertices = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+    faces = [3, 0, 1, 2]
+    mesh = _make_mesh(vertices=vertices, faces=faces, units="m")
+    blob = sgeo.encode(mesh)
+    body = blob[sgeo.HEADER_SIZE :]
+
+    vertex_count = struct.unpack_from("<I", body, 0)[0]
+    face_count = struct.unpack_from("<I", body, 4)[0]
+    assert vertex_count == len(vertices) // 3 == 3
+    assert face_count == len(faces) == 4
+
+    # first vertex triple starts at offset 8 (after the two uint32 counts)
+    first_x = struct.unpack_from("<d", body, 8)[0]
+    first_y = struct.unpack_from("<d", body, 16)[0]
+    first_z = struct.unpack_from("<d", body, 24)[0]
+    assert (first_x, first_y, first_z) == (0.0, 0.0, 0.0)
+
+    # second vertex
+    second_x = struct.unpack_from("<d", body, 32)[0]
+    assert second_x == 1.0
+
+    # faces follow all vertices: 9 doubles = 72 bytes, +8 header = offset 80
+    faces_offset = 8 + len(vertices) * 8
+    decoded_faces = [
+        struct.unpack_from("<i", body, faces_offset + i * 4)[0]
+        for i in range(len(faces))
+    ]
+    assert decoded_faces == faces
+
+    # exact total length: header + counts + vertices + faces, no trailing pad
+    expected_len = sgeo.HEADER_SIZE + 8 + len(vertices) * 8 + len(faces) * 4
+    assert len(blob) == expected_len
+
+
+def test_mesh_with_normals_and_colors_flags_and_pad():
+    vertices = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+    faces = [3, 0, 1, 2]
+    normals = [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]
+    colors = [-1, -16711936, 255]  # signed ARGB-style ints
+    mesh = _make_mesh(
+        vertices=vertices,
+        faces=faces,
+        vertexNormals=normals,
+        colors=colors,
+        units="m",
+    )
+    blob = sgeo.encode(mesh)
+
+    flags = struct.unpack_from("<H", blob, 6)[0]
+    assert flags & int(sgeo.Flags.HAS_NORMALS)
+    assert flags & int(sgeo.Flags.HAS_COLORS)
+    assert not (flags & int(sgeo.Flags.HAS_UVS))
+    assert int(sgeo.Flags.HAS_NORMALS) == 1 << 4
+    assert int(sgeo.Flags.HAS_COLORS) == 1 << 6
+
+    body = blob[sgeo.HEADER_SIZE :]
+
+    # vertices(9) + faces(4): 8 + 72 + 16 = 96 bytes -> already 8-aligned,
+    # so Pad8 before normals adds nothing here.
+    normals_offset = 8 + len(vertices) * 8 + len(faces) * 4
+    assert normals_offset % 8 == 0
+    n0 = struct.unpack_from("<d", body, normals_offset + 2 * 8)[0]
+    assert n0 == 1.0  # third component of first normal
+
+    # colors directly follow the normals (NO pad before colors)
+    colors_offset = normals_offset + len(normals) * 8
+    decoded_colors = [
+        struct.unpack_from("<i", body, colors_offset + i * 4)[0]
+        for i in range(len(colors))
+    ]
+    assert decoded_colors == colors
+
+    # crc still valid
+    stored_crc = struct.unpack_from("<I", blob, 12)[0]
+    assert stored_crc == sgeo.crc32(body)
+
+
+def test_pad8_alignment_when_faces_misaligned():
+    # 3 vertices + 5 faces: 8 + 72 + 20 = 100 bytes body before normals.
+    # 100 % 8 == 4, so Pad8 must add 4 bytes before the normals f64 block.
+    vertices = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+    faces = [4, 0, 1, 2, 3]  # 5 ints
+    normals = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    mesh = _make_mesh(vertices=vertices, faces=faces, vertexNormals=normals, units="m")
+    blob = sgeo.encode(mesh)
+    body = blob[sgeo.HEADER_SIZE :]
+
+    pre_pad = 8 + len(vertices) * 8 + len(faces) * 4
+    assert pre_pad % 8 == 4
+    padded = pre_pad + 4
+    assert padded % 8 == 0
+    # padding bytes are zero
+    assert body[pre_pad:padded] == b"\x00\x00\x00\x00"
+    first_normal = struct.unpack_from("<d", body, padded)[0]
+    assert first_normal == 1.0
+
+
+def test_encode_unknown_raises():
+    with pytest.raises(ValueError):
+        sgeo.encode(object())

--- a/tests/bundle/test_sgeo.py
+++ b/tests/bundle/test_sgeo.py
@@ -26,10 +26,9 @@ def _reference_crc32(data: bytes, poly: int) -> int:
     return crc ^ 0xFFFFFFFF
 
 
-def test_crc32_matches_dotnet_polynomial():
-    # SgeoFormat.cs uses the constant 0xEDB88820 (NOT the canonical IEEE
-    # 0xEDB88320). We replicate it for byte-for-byte parity with the .NET
-    # encoder, so sgeo.crc32 must match a bit-by-bit reference using 0xEDB88820.
+def test_crc32_is_canonical_ieee():
+    # SGEO uses the canonical IEEE-802.3 reflected polynomial 0xEDB88320, so
+    # sgeo.crc32 must match a bit-by-bit reference using that polynomial.
     samples = [
         b"",
         b"SGEO",
@@ -38,18 +37,16 @@ def test_crc32_matches_dotnet_polynomial():
         b"\x00\x01\x02\x03\xff\xfe\xfd",
     ]
     for s in samples:
-        assert sgeo.crc32(s) == _reference_crc32(s, 0xEDB88820)
+        assert sgeo.crc32(s) == _reference_crc32(s, 0xEDB88320)
 
 
-def test_crc32_differs_from_zlib_due_to_nonstandard_poly():
-    # Document the gotcha: SGEO's CRC is NOT standard CRC-32, so it must not be
-    # swapped for zlib.crc32. zlib equals the canonical 0xEDB88320 reference.
+def test_crc32_equals_zlib():
+    # SGEO's CRC is standard CRC-32, so it equals zlib.crc32 (which is how the
+    # encoder computes it — a C-speed call rather than a Python byte loop).
     import zlib
 
-    s = b"the quick brown fox"
-    assert sgeo.crc32(s) == _reference_crc32(s, 0xEDB88820)
-    assert (zlib.crc32(s) & 0xFFFFFFFF) == _reference_crc32(s, 0xEDB88320)
-    assert sgeo.crc32(s) != (zlib.crc32(s) & 0xFFFFFFFF)
+    for s in (b"", b"the quick brown fox", bytes(range(256))):
+        assert sgeo.crc32(s) == (zlib.crc32(s) & 0xFFFFFFFF)
 
 
 def test_unit_encoding_mapping():

--- a/tests/bundle/test_writers.py
+++ b/tests/bundle/test_writers.py
@@ -1,4 +1,5 @@
-"""Core bundle writer tests: write parquet, read it back with DuckDB, check spec conformance."""
+"""Core bundle writer tests: write parquet, read it back with DuckDB, check spec
+conformance."""
 
 from __future__ import annotations
 
@@ -51,7 +52,8 @@ def test_envelope_writer_roundtrip_and_catalog(tmp_path):
     # meta: schema version from the spec
     (ver,) = _q(
         con,
-        f"SELECT schema_version FROM read_parquet('{out}/{BASE}.envelope.meta.parquet')",
+        f"SELECT schema_version FROM "
+        f"read_parquet('{out}/{BASE}.envelope.meta.parquet')",
     )[0:1]
     assert ver[0] == SCHEMA_VERSION == 5
 
@@ -72,20 +74,23 @@ def test_envelope_writer_roundtrip_and_catalog(tmp_path):
     # node_kinds catalog: 6 live (COLLECTION retired/folded)
     n_kind = _q(
         con,
-        f"SELECT count(*) FROM read_parquet('{out}/{BASE}.envelope.node_kinds.parquet')",
+        f"SELECT count(*) FROM "
+        f"read_parquet('{out}/{BASE}.envelope.node_kinds.parquet')",
     )[0][0]
     assert n_kind == 6
 
     # nodes + relations content
     nodes = _q(
         con,
-        f"SELECT id, kind, name, subtype, elevation FROM read_parquet('{out}/{BASE}.envelope.nodes.parquet') ORDER BY id",
+        f"SELECT id, kind, name, subtype, elevation "
+        f"FROM read_parquet('{out}/{BASE}.envelope.nodes.parquet') ORDER BY id",
     )
     assert nodes[0][1] == int(NodeKind.CONTAINER) and nodes[0][3] == "Model"
     assert nodes[1][1] == int(NodeKind.LEVEL) and nodes[1][4] == 3.5
     rels = _q(
         con,
-        f"SELECT rel, src, dst FROM read_parquet('{out}/{BASE}.envelope.relations.parquet') ORDER BY rel",
+        f"SELECT rel, src, dst FROM "
+        f"read_parquet('{out}/{BASE}.envelope.relations.parquet') ORDER BY rel",
     )
     assert (int(Rel.ON_LEVEL), 0, 1) in rels and (int(Rel.IN_MODEL), 0, 0) in rels
 
@@ -106,7 +111,8 @@ def test_eav_writer_roundtrip(tmp_path):
     con = duckdb.connect()
     objs = _q(
         con,
-        f"SELECT object_index, application_id FROM read_parquet('{out}/{BASE}.eav.objects.parquet')",
+        f"SELECT object_index, application_id "
+        f"FROM read_parquet('{out}/{BASE}.eav.objects.parquet')",
     )
     assert objs == [(0, "guid-1")]
 
@@ -147,7 +153,8 @@ def test_geometries_writer_id_is_sha256_and_type_from_header(tmp_path):
     con = duckdb.connect()
     rows = _q(
         con,
-        f"SELECT geometryIndex, id, type FROM read_parquet('{out}/{BASE}.geometries.parquet')",
+        f"SELECT geometryIndex, id, type "
+        f"FROM read_parquet('{out}/{BASE}.geometries.parquet')",
     )
     assert len(rows) == 1
     assert rows[0][0] == 7
@@ -164,7 +171,8 @@ def test_geometries_writer_rejects_non_sgeo(tmp_path):
 
 def test_geometries_sharding(tmp_path):
     out = str(tmp_path)
-    # tiny cap forces a roll: each blob ~24 bytes, cap 30 -> shard 0 gets one, shard 1 next.
+    # tiny cap forces a roll: each blob ~24 bytes, cap 30 -> shard 0 gets one,
+    # shard 1 next.
     w = GeometriesParquetWriter(out, BASE, shard_cap_bytes=30)
     for i in range(3):
         w.add_geometry(i, _fake_sgeo(body=bytes([i]) * 8))

--- a/tests/bundle/test_writers.py
+++ b/tests/bundle/test_writers.py
@@ -1,0 +1,179 @@
+"""Core bundle writer tests: write parquet, read it back with DuckDB, check spec conformance."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+import duckdb
+import pytest
+
+from specklepy.bundle.eav_extraction import EavRow
+from specklepy.bundle.eav_writer import EavWriter
+from specklepy.bundle.envelope_writer import EnvelopeWriter
+from specklepy.bundle.geometries_writer import GeometriesParquetWriter
+from specklepy.bundle.spec import SCHEMA_VERSION, NodeKind, Rel
+
+BASE = "test"
+
+
+def _q(con, sql):
+    return con.execute(sql).fetchall()
+
+
+def test_envelope_writer_roundtrip_and_catalog(tmp_path):
+    out = str(tmp_path)
+    w = EnvelopeWriter(out, BASE)
+    # one container (subtype Model) + one object→container edge
+    w.add_node(
+        0,
+        NodeKind.CONTAINER,
+        "Model A",
+        None,
+        None,
+        None,
+        "Model",
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    w.add_node(
+        1, NodeKind.LEVEL, "L1", None, None, None, None, None, None, None, None, 3.5
+    )
+    w.add_relation(Rel.IN_MODEL, 0, 0, 0)
+    w.add_relation(Rel.ON_LEVEL, 0, 1, 0)
+    w.complete()
+
+    con = duckdb.connect()
+
+    # meta: schema version from the spec
+    (ver,) = _q(
+        con,
+        f"SELECT schema_version FROM read_parquet('{out}/{BASE}.envelope.meta.parquet')",
+    )[0:1]
+    assert ver[0] == SCHEMA_VERSION == 5
+
+    # rel_types catalog: 15 live+reserved (retired absent)
+    (n_rel,) = _q(
+        con,
+        f"SELECT count(*) FROM read_parquet('{out}/{BASE}.envelope.rel_types.parquet')",
+    )[0]
+    assert n_rel == 15
+    # retired ids never present
+    retired = _q(
+        con,
+        f"SELECT count(*) FROM read_parquet('{out}/{BASE}.envelope.rel_types.parquet') "
+        "WHERE rel IN (13,15,16,17,18,19,20,22)",
+    )[0][0]
+    assert retired == 0
+
+    # node_kinds catalog: 6 live (COLLECTION retired/folded)
+    n_kind = _q(
+        con,
+        f"SELECT count(*) FROM read_parquet('{out}/{BASE}.envelope.node_kinds.parquet')",
+    )[0][0]
+    assert n_kind == 6
+
+    # nodes + relations content
+    nodes = _q(
+        con,
+        f"SELECT id, kind, name, subtype, elevation FROM read_parquet('{out}/{BASE}.envelope.nodes.parquet') ORDER BY id",
+    )
+    assert nodes[0][1] == int(NodeKind.CONTAINER) and nodes[0][3] == "Model"
+    assert nodes[1][1] == int(NodeKind.LEVEL) and nodes[1][4] == 3.5
+    rels = _q(
+        con,
+        f"SELECT rel, src, dst FROM read_parquet('{out}/{BASE}.envelope.relations.parquet') ORDER BY rel",
+    )
+    assert (int(Rel.ON_LEVEL), 0, 1) in rels and (int(Rel.IN_MODEL), 0, 0) in rels
+
+
+def test_eav_writer_roundtrip(tmp_path):
+    out = str(tmp_path)
+    w = EavWriter(out, BASE)
+    rows = [
+        EavRow("guid-1", "properties.Pset.Width", "100", 100.0, "number", "mm", None),
+        EavRow("guid-1", "name", "Wall", None, "string", None, None),
+        EavRow(
+            "guid-1", "properties.Pset.LoadBearing", "true", None, "boolean", None, None
+        ),
+    ]
+    w.add_rows("guid-1", rows)
+    w.complete()
+
+    con = duckdb.connect()
+    objs = _q(
+        con,
+        f"SELECT object_index, application_id FROM read_parquet('{out}/{BASE}.eav.objects.parquet')",
+    )
+    assert objs == [(0, "guid-1")]
+
+    # join eav -> paths and coalesce values
+    res = _q(
+        con,
+        f"""
+        SELECT p.path, e.value_string, e.value_double, e.value_boolean, e.unit
+        FROM read_parquet('{out}/{BASE}.eav.eav.parquet') e
+        JOIN read_parquet('{out}/{BASE}.eav.paths.parquet') p USING (path_index)
+        ORDER BY p.path
+        """,
+    )
+    by_path = {r[0]: r for r in res}
+    assert by_path["properties.Pset.Width"][2] == 100.0
+    assert by_path["properties.Pset.Width"][4] == "mm"
+    assert by_path["name"][1] == "Wall"
+    assert by_path["properties.Pset.LoadBearing"][3] is True
+
+
+def _fake_sgeo(primitive_type: int = 0, body: bytes = b"\x00" * 8) -> bytes:
+    """Minimal valid-enough SGEO blob: 16-byte header (magic/version/type) + body."""
+    header = bytearray(16)
+    header[0:4] = b"SGEO"
+    header[4] = 1
+    header[5] = primitive_type
+    return bytes(header) + body
+
+
+def test_geometries_writer_id_is_sha256_and_type_from_header(tmp_path):
+    out = str(tmp_path)
+    blob = _fake_sgeo(primitive_type=0, body=b"\x01\x02\x03\x04\x05\x06\x07\x08")
+    w = GeometriesParquetWriter(out, BASE)
+    w.add_geometry(7, blob)
+    w.add_geometry(7, blob)  # dedup by geometryIndex -> one row
+    w.complete()
+
+    con = duckdb.connect()
+    rows = _q(
+        con,
+        f"SELECT geometryIndex, id, type FROM read_parquet('{out}/{BASE}.geometries.parquet')",
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == 7
+    assert rows[0][1] == hashlib.sha256(blob).hexdigest()
+    assert rows[0][2] == "mesh"
+
+
+def test_geometries_writer_rejects_non_sgeo(tmp_path):
+    w = GeometriesParquetWriter(str(tmp_path), BASE)
+    with pytest.raises(ValueError):
+        w.add_geometry(0, b"NOPE")
+    w.complete()
+
+
+def test_geometries_sharding(tmp_path):
+    out = str(tmp_path)
+    # tiny cap forces a roll: each blob ~24 bytes, cap 30 -> shard 0 gets one, shard 1 next.
+    w = GeometriesParquetWriter(out, BASE, shard_cap_bytes=30)
+    for i in range(3):
+        w.add_geometry(i, _fake_sgeo(body=bytes([i]) * 8))
+    w.complete()
+
+    assert os.path.exists(f"{out}/{BASE}.geometries.parquet")
+    assert os.path.exists(f"{out}/{BASE}.geometries.1.parquet")
+    con = duckdb.connect()
+    total = _q(
+        con, f"SELECT count(*) FROM read_parquet('{out}/{BASE}.geometries*.parquet')"
+    )[0][0]
+    assert total == 3

--- a/uv.lock
+++ b/uv.lock
@@ -522,6 +522,48 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/ee/69340af74a3aa21838f14c16a0dd3e58461896ccba41f6bc7f0a01536e23/duckdb-1.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ddd9533ce80f9b851bdd6276960a9286166514a9ceca43d5bc2f0d5842c490d", size = 32656177, upload-time = "2026-06-17T10:47:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/9da267ade389d4e7e533ac0c77b3a7041513a66efab93beb84f27627b0b8/duckdb-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360f2542d09759c3739400f8b787e29b43ba0da665c21756216291458bf6fc59", size = 17318966, upload-time = "2026-06-17T10:47:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/ad73c1a396288e443b18af50819448060b318c1e933305167c1d7f98a507/duckdb-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0cf932055061e544d3fa27cc6c147da25f3f681ee5980157fb55e77d6c2d9c63", size = 15467572, upload-time = "2026-06-17T10:47:36.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/06/2c52ce3b97c3f21111f3c98a2121ed002e33f86488f55098a37825af6d4a/duckdb-1.5.4-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2d58d39f5e65419cdc27e3875cba4a729a3bbf6bf4016aefb4a2a65335a1d42", size = 19344044, upload-time = "2026-06-17T10:47:38.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7d/5c0cc66fb90a1b14474eebb5ab535eacc51cb20b0e45358348b51c07abc9/duckdb-1.5.4-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9a10dc40469b9c0e458625d2a8359461a982c6151bb53ff259fea00c4695ad4", size = 21448215, upload-time = "2026-06-17T10:47:40.617Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/16c3ea201855cdfb7dde52ea3678d0536861cb485ffad46cf345436d658d/duckdb-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:3565550adbf160ef7a2ee3395470570182f11233983ad818bd7d5f9e349f92b2", size = 13132138, upload-time = "2026-06-17T10:47:43.085Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bb/7921dabd50daef3969f14cd8a5a14c24eee337db7914a462f2defa8add92/duckdb-1.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fb41d9cfccb7e44511eeeed263ae98143ca63bdb1ef84631ba637c314efa1b5", size = 32663142, upload-time = "2026-06-17T10:47:45.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/83/2137765eaba6a9aefe3bb9848ddaac7407fe3ba19b292f98b31f3b7ab27f/duckdb-1.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ba7b666bc9c78d6a930ee9f469024149f0c6a23fb7d2c3418aad6774339bec0", size = 17321485, upload-time = "2026-06-17T10:47:47.778Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/a02c1ee43fd7e8cf1fc2e3d377f3dcf9d4a3e58a4549557516e1866ff0da/duckdb-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9d9e6817fcbc09d2605a2c8c041ac7824d738d917c35a4d427e977647e1d7944", size = 15470820, upload-time = "2026-06-17T10:47:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/a243d30223b024bc6057abe472b002cff01e97efefb4d2f0b0dcc5aece0b/duckdb-1.5.4-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02dd9f9a6124069213f13e3a474c208028c472fe1acdae12b38761f954fe4fc6", size = 19341849, upload-time = "2026-06-17T10:47:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/a5d48de4771e2403a8ef26a20dc7457b1c8f7e398ff0caf9c0cad8805f89/duckdb-1.5.4-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccc7f2694d02b4763fee61021d45e12f7bc5743993686563957df0cef799fbae", size = 21451698, upload-time = "2026-06-17T10:47:54.653Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/8244d7741b4afae67775cf0cb0d4eb9e923a83110907e4801e17fa078480/duckdb-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:4c430e788d99b50854209bf2833ba36a45df75e57f86efb477046cd408bbd077", size = 13132643, upload-time = "2026-06-17T10:47:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/57/8169822a37f6dd7d561c567f9007e3cf04bf97bccb619afe90db849c0962/duckdb-1.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:e2dc8340cfb6006025a798c50f40126d6e945a1d2487be94667bb4166556ce7b", size = 13986386, upload-time = "2026-06-17T10:47:59.345Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -1639,6 +1681,63 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/bf/a34fee1d624152124fa8355c42f34195ad5fe5233ce5bb87946432047d52/pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb", size = 35076681, upload-time = "2026-04-21T08:51:46.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/41/64180033d7027afce12dc96d0fe1f504c6fa112190582b458acea2399530/pyarrow-24.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147", size = 36684260, upload-time = "2026-04-21T08:51:53.642Z" },
+    { url = "https://files.pythonhosted.org/packages/57/02/9b9320e673dd8a99411fac78690f3df92f6dd6f59754c750110bca66d64e/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3a577bd840ca83f646f0a625dbc571dba7044c43c2d1503afc378b570954345c", size = 45698566, upload-time = "2026-04-21T10:46:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041", size = 48835562, upload-time = "2026-04-21T10:46:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/63/097510448e47e4091faa41c43ba92f97cecaab8f4535b56a3d149578f634/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2392d954fcb920f42d230284b677605e4e2fbb11f2821e823e642abd67fbb491", size = 49394997, upload-time = "2026-04-21T10:46:18.08Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6b/c047d6222ab279024a062742d1807e2fbaf27bba88a98637299ff47b9236/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bec9373df11544592b0ba7ec2af0e35059e5f0e7647c6183a854dedd193298f1", size = 51911424, upload-time = "2026-04-21T10:46:25.347Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ba/464cc70761c2a525d97ebd84e21c31ebd47f3ef4bdcee117009f51c46f24/pyarrow-24.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:c42ab9439498270139cc63e18847a02afe5c8b3ed9c931266533cfe378bd3591", size = 27251730, upload-time = "2026-04-21T10:46:30.913Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple/" }
@@ -2215,8 +2314,14 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+bundle = [
+    { name = "duckdb" },
+    { name = "pyarrow" },
+]
 speckleifc = [
+    { name = "duckdb" },
     { name = "ifcopenshell" },
+    { name = "pyarrow" },
 ]
 
 [package.dev-dependencies]
@@ -2248,14 +2353,18 @@ requires-dist = [
     { name = "appdirs", specifier = ">=1.4.4" },
     { name = "attrs", specifier = ">=24.3.0" },
     { name = "deprecated", specifier = ">=1.2.15" },
+    { name = "duckdb", marker = "extra == 'bundle'", specifier = ">=1.1.0" },
+    { name = "duckdb", marker = "extra == 'speckleifc'", specifier = ">=1.1.0" },
     { name = "gql", extras = ["requests", "websockets"], specifier = ">=3.5.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ifcopenshell", marker = "extra == 'speckleifc'", specifier = ">=0.8.5" },
+    { name = "pyarrow", marker = "extra == 'bundle'", specifier = ">=17.0.0" },
+    { name = "pyarrow", marker = "extra == 'speckleifc'", specifier = ">=17.0.0" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "ujson", specifier = ">=5.10.0" },
 ]
-provides-extras = ["speckleifc"]
+provides-extras = ["bundle", "speckleifc"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Description & motivation

Adds the **artefact bundle** producer to specklepy and wires the IFC converter (`speckleifc`) to emit it — the parquet triple (flat `eav` store + `envelope` graph of nodes/typed relations + `geometries` SGEO blobs, read via DuckDB), uploaded through the v2 data endpoints. This is the Python counterpart of the .NET (`Speckle.Objects`/`Speckle.Sdk`) and native (`nw/rvextract`) producers, sourcing its vocabulary and table schemas from the generated, vendored `speckle-bundle-spec` (single source of truth — no drift).

**This PR is purely additive and safe to merge:** the IFC importer's default behaviour (v1 detached-object send) is **unchanged**, and the bundle path is **opt-in** via the `SPECKLE_IFC_BUNDLE` env var. Existing SDK users are unaffected.

Why it's worth it (vs v1, measured on SHEUNG WAN ARCH, 14.5k elements): **8× fewer addressable objects** (14.5k vs 122k), **~8× smaller upload** (7.2 MB vs 57 MB gzipped / 255 MB raw JSON), and after a CRC fix the bundle write is **~2.4× faster** than v1 serialization.

## Changes

**New `specklepy/bundle/` package (opt-in, `specklepy[bundle]` extra = pyarrow + duckdb):**
- `pipeline.py` — `ObjectsArtifactPipeline`, the typed producer API (nodes/relations/geometries/eav).
- `eav_writer` / `envelope_writer` / `geometries_writer` (parquet + zstd, geometry sharding), `parquet_table_writer`, `interner`.
- `sgeo.py` — SGEO v1 geometry encoder (Mesh byte-exact vs .NET).
- `eav_extraction.py` — EAV property flattening (parity with the server's `eavExtraction.ts`).
- `upload.py` — v2 `sign → PUT → complete` upload over httpx.
- `spec/` — vendored generated `bundle_spec.py` / `bundle_schemas.py` (from `speckle-bundle-spec`).

**`speckleifc`:**
- `bundle_exporter.py` — drives the pipeline from the converted tree: collections, instances/definitions, materials, levels, properties; MEP topology (`IN_SYSTEM` + `CONNECTS_TO`); and a default **scene view = Level › IFC class**.
- `importer.py` — MEP topology extraction gated behind `emit_topology` (off by default → **v1 output byte-identical**).
- `main.py` — `SPECKLE_IFC_BUNDLE=1` opt-in; default is the original v1 send verbatim. Bundle producer imported lazily so the v1 path never loads pyarrow.

**SDK (additive):**
- `ModelIngestion` gains the top-level `versionId` field and the model-ingestion queries now select it (the bundle path's pre-allocated version id).
- Two new `Base` proxy types (`SystemProxy`, `ConnectionProxy`).

**Validation:**
- 49 new unit tests (writers, sgeo, eav, pipeline, exporter).
- All SHEUNG WAN + Digital Hub IFC models export bundles that pass the spec validator.
- **Both paths exercised end-to-end against a live server** (testing2): v1 (env unset) and bundle (env=1), including the authored-system path on the Digital Hub MEP files (HZG/LFT/SAN — real `IfcSystem` → System containers + `IN_SYSTEM` + `CONNECTS_TO`).

## Validated live on testing2

Beyond the unit tests + spec validator, the bundle path was run **end-to-end against a live 4.0 server** (`testing2.speckle.dev`, project *Big Truck Testing* / `7c22fc893d`) across a wide spread of real-world IFCs (IFC2X3 + IFC4, 9 MB → 1.65 GB). Every processable file produced a spec-valid bundle and committed a version.

**Canonical set — SHEUNG WAN (scene view + topology):** [STR](https://testing2.speckle.dev/projects/7c22fc893d/models/f765a21db0) · [MEP](https://testing2.speckle.dev/projects/7c22fc893d/models/fe90520ccc) · [ARCH](https://testing2.speckle.dev/projects/7c22fc893d/models/c05e8d17ea)

**Authored MEP systems — Digital Hub** (real `IfcSystem` → System containers + `IN_SYSTEM` + `CONNECTS_TO`): [HZG](https://testing2.speckle.dev/projects/7c22fc893d/models/a557a0079b) (42 systems) · [LFT](https://testing2.speckle.dev/projects/7c22fc893d/models/576006e911) (4) · [SAN](https://testing2.speckle.dev/projects/7c22fc893d/models/c28d6c0e4e) (19)

**Scale & diversity** (full produce → upload → version; time + peak RAM measured):

| Model | Size | Total | Peak RAM | Objects | Systems | Bundle | Link |
|---|---|---|---|---|---|---|---|
| DOE-GSE-ARC (IFC2X3) | 113 MB | 25 s | 3.3 GB | 11.5k | 86 | 19 MB | [`d2cba53ad1`](https://testing2.speckle.dev/projects/7c22fc893d/models/d2cba53ad1) |
| TP1-HEN-ARCA (IFC4) | 277 MB | 101 s | 9.8 GB | 15.9k | 0 | 107 MB | [`bb56854f02`](https://testing2.speckle.dev/projects/7c22fc893d/models/bb56854f02) |
| OSS-MJL-ME (MEP) | 296 MB | 73 s | 34 GB | 20.6k | 138 | 63 MB | [`f48ca37f8a`](https://testing2.speckle.dev/projects/7c22fc893d/models/f48ca37f8a) |
| 91912-HHBR-A | 344 MB | 46 s | 16 GB | 9.8k | 0 | 31 MB | [`da57c30ea5`](https://testing2.speckle.dev/projects/7c22fc893d/models/da57c30ea5) |
| ElbTower | 1.65 GB | 185 s | 26 GB | 29k | 0 | 61 MB | [`2ceda709fb`](https://testing2.speckle.dev/projects/7c22fc893d/models/2ceda709fb) |

Notes:
- **`convert()` (ifcopenshell geometry) is 85–95% of wall time and ~all peak RAM**; the bundle writers add little. Peak RAM tracks geometry complexity / iterator thread count (`cpu_count`), not file size — see the `num_threads` / deflection / streaming levers for bounding it.
- **Bundle vs OG v1 on ElbTower**: output stage **9.4 s vs 110 s (~12× faster)**, total **185 s vs 317 s**, identical peak RAM ([bundle](https://testing2.speckle.dev/projects/7c22fc893d/models/2ceda709fb) vs [v1](https://testing2.speckle.dev/projects/7c22fc893d/models/9e86b0c7d8)).
- One source file (a Revizto `.nwc`→IFC export) had a malformed `FILE_SCHEMA (('IFC4',''))` header that ifcopenshell rejects outright; recovered with a one-line header fix, then [processed](https://testing2.speckle.dev/projects/7c22fc893d/models/1e8b40d022). Not a producer issue.

## To-do before merge

- [ ] Confirm whether the v1-visible SDK addition (`ModelIngestion.versionId`) is acceptable as-is.
- [ ] Heads-up: the bundle path only works against a server exposing the v2 data endpoints **and** a viewer that reads bundles + `scene_views`; flip `SPECKLE_IFC_BUNDLE` only there.
- [x] Companion change: the SGEO CRC was standardised to the canonical IEEE poly across the stack (separate PRs in `speckle-sharp-sdk` + `speckle-oda`); merge order doesn't matter since nothing validates the CRC yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
