### PR TITLE
Feature: decode SGEO primitives

### DIFF
--- a/src/speckleifc/bundle_exporter.py
+++ b/src/speckleifc/bundle_exporter.py
@@ -105,6 +105,7 @@ class IfcBundleExporter:
                 opacity=float(_attr(material, "opacity", 1.0)),
                 metalness=float(_attr(material, "metalness", 0.0)),
                 roughness=float(_attr(material, "roughness", 1.0)),
+                name=_attr(material, "name"),
             )
             for mesh_id in _attr(proxy, "objects", []) or []:
                 geo_k = self._pipeline.intern_geometry_id(mesh_id)

--- a/src/specklepy/bundle/__init__.py
+++ b/src/specklepy/bundle/__init__.py
@@ -6,6 +6,10 @@ parquet schemas are sourced from the generated, vendored
 repo). The typed producer API is
 :class:`~specklepy.bundle.pipeline.ObjectsArtifactPipeline`; upload via
 :class:`~specklepy.bundle.upload.ArtifactPipeline`.
+
+Geometry blobs are encoded and decoded by :mod:`specklepy.bundle.sgeo`
+(``sgeo.encode`` / ``sgeo.decode``), which receivers use to read a downloaded
+bundle back. Decoding covers MESH so far.
 """
 
 from specklepy.bundle.pipeline import ObjectsArtifactPipeline

--- a/src/specklepy/bundle/__init__.py
+++ b/src/specklepy/bundle/__init__.py
@@ -9,7 +9,7 @@ repo). The typed producer API is
 
 Geometry blobs are encoded and decoded by :mod:`specklepy.bundle.sgeo`
 (``sgeo.encode`` / ``sgeo.decode``), which receivers use to read a downloaded
-bundle back. Decoding covers MESH so far.
+bundle back. Decoding covers every primitive the encoder emits.
 """
 
 from specklepy.bundle.pipeline import ObjectsArtifactPipeline

--- a/src/specklepy/bundle/pipeline.py
+++ b/src/specklepy/bundle/pipeline.py
@@ -195,14 +195,19 @@ class ObjectsArtifactPipeline:
         opacity: float,
         metalness: float,
         roughness: float,
+        name: str | None = None,
     ) -> int:
-        """Intern a MATERIAL value-node (inline render value), writing it once."""
+        """Intern a MATERIAL value-node (inline render value), writing it once.
+
+        ``name`` is the source material's display name; without it, materials
+        that share the same render values are indistinguishable to consumers.
+        """
         k, is_new = self._node_interner.get_or_add("mat:" + material_key)
         if is_new:
             self._envelope.add_node(
                 k,
                 NodeKind.MATERIAL,
-                None,
+                name,
                 None,
                 None,
                 None,

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -21,8 +21,11 @@ Conventions: little-endian throughout; f64 = IEEE-754 double; the body starts
 8-byte aligned at 0x10 and every f64 array stays 8-aligned (u32 scalars are
 padded in pairs via :func:`_pad8`).
 
-:func:`encode` writes blobs; :func:`decode` / :func:`decode_mesh` read them back
-for the receive side of the artefact path. Decoding currently covers MESH only.
+:func:`encode` writes blobs; :func:`decode` reads them back for the receive side
+of the artefact path, covering every primitive the encoder emits.
+:func:`decode_mesh` is a raw-array fast path for MESH only — meshes are the
+dense case where allocating a ``Base`` per geometry dominates, and connectors
+that bake straight into a host application want the flat arrays anyway.
 """
 
 from __future__ import annotations
@@ -645,29 +648,362 @@ def decode_mesh(blob: bytes, *, verify: bool = True) -> DecodedMesh:
 def decode(blob: bytes, *, verify: bool = True) -> Base:
     """Decode an SGEO v1 blob into the Speckle object it was encoded from.
 
-    The inverse of :func:`encode`. Only MESH is supported so far; every other
-    primitive raises :class:`SgeoDecodeError`.
+    The inverse of :func:`encode`, covering every primitive the encoder emits.
+
+    Raises:
+        SgeoDecodeError: on a malformed blob or an unknown primitive code.
     """
     header = decode_header(blob)
-    if header.primitive_type != PrimitiveType.MESH:
-        primitive = header.primitive
-        name = primitive.name if primitive else f"code {header.primitive_type}"
-        raise SgeoDecodeError(f"No SGEO decoder for primitive {name} yet.")
+    primitive = header.primitive
+    if primitive is None:
+        raise SgeoDecodeError(f"Unknown SGEO primitive code {header.primitive_type}.")
+    if verify:
+        verify_crc(blob)
 
-    from specklepy.objects.geometry.mesh import Mesh
+    if primitive is PrimitiveType.MESH:
+        # the raw path already builds the arrays; just wrap them
+        from specklepy.objects.geometry.mesh import Mesh
 
-    mesh = decode_mesh(blob, verify=verify)
-    return Mesh(
-        vertices=mesh.vertices,
-        faces=mesh.faces,
-        vertexNormals=mesh.vertex_normals,
-        textureCoordinates=mesh.texture_coordinates,
-        colors=mesh.colors,
-        units=mesh.units,
+        mesh = decode_mesh(blob, verify=False)
+        return Mesh(
+            vertices=mesh.vertices,
+            faces=mesh.faces,
+            vertexNormals=mesh.vertex_normals,
+            textureCoordinates=mesh.texture_coordinates,
+            colors=mesh.colors,
+            units=mesh.units,
+        )
+
+    decoder = _DECODERS.get(primitive)
+    if decoder is None:
+        raise SgeoDecodeError(f"No SGEO decoder for primitive {primitive.name}.")
+    return decoder(header, _Reader(memoryview(blob)[HEADER_SIZE:]))
+
+
+# ── per-primitive decoders ─────────────────────────────────────────────────
+#
+# Each inverts the matching ``_encode_*`` above; read them side by side. The
+# encoders are the specification — where a field is *derived* rather than stored
+# (a Circle's centre, an array length) it is called out, because that is where a
+# decoder silently invents data if it guesses wrong.
+
+
+def _decode_line(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.line import Line
+
+    domain = r.interval()
+    start = r.point(header.units)
+    end = r.point(header.units)
+    line = Line(start=start, end=end, units=header.units)
+    line.domain = domain
+    return line
+
+
+def _decode_polyline(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.polyline import Polyline
+
+    count = r.u32()
+    r.u32()  # reserved
+    polyline = Polyline(value=r.f64s(count * 3), units=header.units)
+    # Polyline has no `closed` field — it computes is_closed() from its points —
+    # so the flag round-trips as the dynamic member the producer set.
+    polyline["closed"] = bool(header.flags & Flags.CLOSED)
+    return polyline
+
+
+def _decode_polycurve(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.polycurve import Polycurve
+
+    count = r.u32()
+    r.u32()  # reserved
+    segments = []
+    for _ in range(count):
+        length = r.u32()
+        r.u32()  # reserved
+        # each segment is a complete nested SGEO blob, CRC included
+        segments.append(decode(r.blob(length)))
+        r.align8()
+    return Polycurve(segments=segments, units=header.units)
+
+
+def _decode_curve(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.curve import Curve
+
+    display = r.polyline_body(header.units, closed=bool(header.flags & Flags.CLOSED))
+
+    degree = r.u32()
+    point_count = r.u32()
+    knot_count = r.u32()
+    r.u32()  # reserved
+    domain = r.interval()
+
+    points = r.f64s(point_count * 3)
+    rational = bool(header.flags & Flags.RATIONAL)
+    # weights are written only when rational, one per control point — the count
+    # is not stored, so it has to come from point_count
+    weights = r.f64s(point_count) if rational else []
+    knots = r.f64s(knot_count)
+
+    curve = Curve(
+        degree=degree,
+        periodic=bool(header.flags & Flags.PERIODIC),
+        rational=rational,
+        points=points,
+        weights=weights,
+        knots=knots,
+        # NB: the encoder sets CLOSED from `_is_closed(c.displayValue)`, not from
+        # `c.closed` — the field itself never reaches the wire. For a producer
+        # that keeps the two in step (Blender sets both from `use_cyclic_u`) this
+        # is faithful; for one that disagrees, the display polyline wins.
+        closed=bool(header.flags & Flags.CLOSED),
+        displayValue=display,
+        units=header.units,
+        bbox=None,
+    )
+    curve.domain = domain
+    return curve
+
+
+def _decode_arc(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.arc import Arc
+
+    plane = r.plane(header.units)
+    start = r.point(header.units)
+    mid = r.point(header.units)
+    end = r.point(header.units)
+    arc = Arc(
+        plane=plane,
+        startPoint=start,
+        midPoint=mid,
+        endPoint=end,
+        units=header.units,
+    )
+    arc.domain = r.interval()
+    return arc
+
+
+def _decode_circle(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.circle import Circle
+
+    radius = r.f64()
+    domain = r.interval()
+    plane = r.plane(header.units)
+    # `center` is not on the wire: the encoder writes only radius + domain +
+    # plane, and a circle's centre is its plane origin by construction.
+    circle = Circle(plane=plane, center=plane.origin, radius=radius, units=header.units)
+    circle.domain = domain
+    return circle
+
+
+def _decode_points(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.point import Point
+    from specklepy.objects.geometry.point_cloud import PointCloud
+
+    count = r.u32()
+    r.u32()  # reserved
+    coords = r.f64s(count * 3)
+
+    colors = r.i32s(count) if header.flags & Flags.HAS_COLORS else []
+    sizes: List[float] = []
+    if header.flags & Flags.HAS_SIZES:
+        r.align8()
+        sizes = r.f64s(count)
+
+    # A lone Point and a one-point PointCloud with no colours or sizes encode to
+    # identical bytes, so the distinction cannot be recovered. Prefer Point: it
+    # is what a single-point blob almost always was, and it is the cheaper shape.
+    if count == 1 and not colors and not sizes:
+        return Point(x=coords[0], y=coords[1], z=coords[2], units=header.units)
+
+    points = [
+        Point(
+            x=coords[i],
+            y=coords[i + 1],
+            z=coords[i + 2],
+            units=header.units,
+        )
+        for i in range(0, len(coords), 3)
+    ]
+    cloud = PointCloud(points=points, units=header.units)
+    if colors:
+        cloud["colors"] = colors
+    if sizes:
+        cloud["sizes"] = sizes
+    return cloud
+
+
+def _decode_ellipse(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.ellipse import Ellipse
+
+    first_radius = r.f64()
+    second_radius = r.f64()
+    domain = r.interval()
+    plane = r.plane(header.units)
+
+    ellipse = Ellipse(
+        plane=plane,
+        first_radius=first_radius,
+        second_radius=second_radius,
+        units=header.units,
+    )
+    ellipse.domain = domain
+    if header.flags & Flags.HAS_TRIM_DOMAIN:
+        ellipse["trimDomain"] = r.interval()
+    return ellipse
+
+
+def _decode_spiral(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.spiral import Spiral
+
+    display = r.polyline_body(header.units, closed=bool(header.flags & Flags.CLOSED))
+
+    spiral_type = r.u32()
+    r.u32()  # reserved
+    start = r.point(header.units)
+    end = r.point(header.units)
+    plane = r.plane(header.units)
+    turns = r.f64()
+    pitch_axis = r.vector(header.units)
+    pitch = r.f64()
+    domain = r.interval()
+
+    spiral = Spiral(
+        start_point=start,
+        end_point=end,
+        plane=plane,
+        turns=turns,
+        pitch=pitch,
+        pitch_axis=pitch_axis,
+        units=header.units,
+    )
+    spiral.domain = domain
+    spiral["spiralType"] = spiral_type
+    # an all-zero leading polyline means the producer had no displayValue
+    if display.value:
+        spiral["displayValue"] = display
+    return spiral
+
+
+def _decode_box(header: SgeoHeader, r: _Reader) -> Base:
+    from specklepy.objects.geometry.box import Box
+
+    plane = r.plane(header.units)
+    return Box(
+        basePlane=plane,
+        xSize=r.interval(),
+        ySize=r.interval(),
+        zSize=r.interval(),
+        units=header.units,
     )
 
 
+_DECODERS = {
+    PrimitiveType.LINE: _decode_line,
+    PrimitiveType.POLYLINE: _decode_polyline,
+    PrimitiveType.POLYCURVE: _decode_polycurve,
+    PrimitiveType.CURVE: _decode_curve,
+    PrimitiveType.ARC: _decode_arc,
+    PrimitiveType.CIRCLE: _decode_circle,
+    PrimitiveType.POINTS: _decode_points,
+    PrimitiveType.ELLIPSE: _decode_ellipse,
+    PrimitiveType.SPIRAL: _decode_spiral,
+    PrimitiveType.BOX: _decode_box,
+}
+
+
 # ── low-level body readers ─────────────────────────────────────────────────
+
+
+class _Reader:
+    """A cursor over an SGEO body, mirroring the encoder's writers one for one.
+
+    Offsets are body-relative, which is what makes :meth:`align8` the exact
+    inverse of :func:`_pad8` — the body always starts 8-aligned at 0x10, so the
+    two agree.
+    """
+
+    __slots__ = ("_body", "offset")
+
+    def __init__(self, body: memoryview) -> None:
+        self._body = body
+        self.offset = 0
+
+    def _take(self, size: int, label: str) -> int:
+        start = self.offset
+        if start + size > len(self._body):
+            raise SgeoDecodeError(
+                f"SGEO body truncated reading {label}: need {size} bytes at "
+                f"offset {start}, only {max(0, len(self._body) - start)} remain."
+            )
+        self.offset = start + size
+        return start
+
+    def u32(self) -> int:
+        return struct.unpack_from("<I", self._body, self._take(4, "uint32"))[0]
+
+    def f64(self) -> float:
+        return struct.unpack_from("<d", self._body, self._take(8, "float64"))[0]
+
+    def f64s(self, count: int) -> List[float]:
+        if count <= 0:
+            return []
+        at = self._take(count * 8, f"{count} float64s")
+        return list(struct.unpack_from(f"<{count}d", self._body, at))
+
+    def i32s(self, count: int) -> List[int]:
+        if count <= 0:
+            return []
+        at = self._take(count * 4, f"{count} int32s")
+        return list(struct.unpack_from(f"<{count}i", self._body, at))
+
+    def blob(self, size: int) -> bytes:
+        at = self._take(size, f"{size}-byte nested blob")
+        return bytes(self._body[at : at + size])
+
+    def align8(self) -> None:
+        self.offset = _align8(self.offset)
+
+    def interval(self):
+        from specklepy.objects.primitive import Interval
+
+        return Interval(start=self.f64(), end=self.f64())
+
+    def point(self, units: Optional[str]):
+        from specklepy.objects.geometry.point import Point
+
+        return Point(x=self.f64(), y=self.f64(), z=self.f64(), units=units)
+
+    def vector(self, units: Optional[str]):
+        from specklepy.objects.geometry.vector import Vector
+
+        return Vector(x=self.f64(), y=self.f64(), z=self.f64(), units=units)
+
+    def plane(self, units: Optional[str]):
+        from specklepy.objects.geometry.plane import Plane
+
+        return Plane(
+            origin=self.point(units),
+            normal=self.vector(units),
+            xdir=self.vector(units),
+            ydir=self.vector(units),
+            units=units,
+        )
+
+    def polyline_body(self, units: Optional[str], closed: bool = False):
+        """Read the render polyline that leads a CURVE or SPIRAL body.
+
+        The inverse of :func:`_polyline_body`, trailing ``_pad8`` included — the
+        analytical definition that follows is f64-aligned only because of it.
+        """
+        from specklepy.objects.geometry.polyline import Polyline
+
+        count = self.u32()
+        self.u32()  # reserved
+        value = self.f64s(count * 3)
+        self.align8()
+        polyline = Polyline(value=value, units=units)
+        polyline["closed"] = closed
+        return polyline
 
 
 def _align8(offset: int) -> int:

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -481,10 +481,10 @@ def try_get_primitive_type(geometry) -> Optional[int]:
 # ── decoding ───────────────────────────────────────────────────────────────
 #
 # The receive side of the artefact path: connectors that load a 4.0 bundle read
-# geometry blobs back out of the geometries table. Only MESH is implemented so
-# far — the other primitives raise :class:`SgeoDecodeError` rather than
-# silently returning nothing, so a caller can tell "not supported yet" from
-# "no geometry".
+# geometry blobs back out of the geometries table. Every primitive the encoder
+# emits can be decoded; unknown or corrupt blobs raise :class:`SgeoDecodeError`
+# rather than silently returning nothing, so a caller can tell "not supported"
+# from "no geometry".
 #
 # Two levels, deliberately: :func:`decode_mesh` returns a plain
 # :class:`DecodedMesh` of raw arrays for consumers that bake straight into a

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -1,4 +1,4 @@
-"""SGEO v1 geometry encoder — a byte-for-byte port of the .NET ``SgeoEncoder``.
+"""SGEO v1 geometry codec — a byte-for-byte port of the .NET ``SgeoEncoder``.
 
 SGEO is Speckle's binary geometry-family format: one opaque blob per geometry
 buffer, a fixed 16-byte little-endian header followed by a per-primitive body.
@@ -20,14 +20,21 @@ Header (16 bytes, little-endian)::
 Conventions: little-endian throughout; f64 = IEEE-754 double; the body starts
 8-byte aligned at 0x10 and every f64 array stays 8-aligned (u32 scalars are
 padded in pairs via :func:`_pad8`).
+
+:func:`encode` writes blobs; :func:`decode` / :func:`decode_mesh` read them back
+for the receive side of the artefact path. Decoding currently covers MESH only.
 """
 
 from __future__ import annotations
 
 import struct
 import zlib
+from dataclasses import dataclass
 from enum import IntEnum, IntFlag
-from typing import Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from specklepy.objects.base import Base
 
 MAGIC = b"SGEO"
 VERSION_1 = 1
@@ -466,3 +473,239 @@ def try_get_primitive_type(geometry) -> Optional[int]:
     """Return the SGEO primitive type code if encodable, else ``None``."""
     primitive = _PRIMITIVE_TYPES.get(type(geometry).__name__)
     return int(primitive) if primitive is not None else None
+
+
+# ── decoding ───────────────────────────────────────────────────────────────
+#
+# The receive side of the artefact path: connectors that load a 4.0 bundle read
+# geometry blobs back out of the geometries table. Only MESH is implemented so
+# far — the other primitives raise :class:`SgeoDecodeError` rather than
+# silently returning nothing, so a caller can tell "not supported yet" from
+# "no geometry".
+#
+# Two levels, deliberately: :func:`decode_mesh` returns a plain
+# :class:`DecodedMesh` of raw arrays for consumers that bake straight into a
+# host application (no Base allocation per mesh, which dominates on dense
+# scenes), and :func:`decode` wraps that into a real ``Mesh`` for consumers
+# that want the object model.
+
+
+class SgeoDecodeError(ValueError):
+    """A blob is not valid SGEO v1, or holds a primitive we cannot decode yet."""
+
+
+_UNIT_DECODING = {code: unit for unit, code in _UNIT_ENCODING.items()}
+
+
+def get_unit_from_encoding(code: int) -> Optional[str]:
+    """Inverse of :func:`get_encoding_from_unit`; ``None`` for the 0 sentinel.
+
+    Not round-trip-exact by construction: the encoder maps every unrecognised
+    unit string to 0, so 0 decodes to ``None`` rather than to whatever the
+    producer originally had.
+    """
+    return _UNIT_DECODING.get(code)
+
+
+@dataclass(frozen=True)
+class SgeoHeader:
+    """The fixed 16-byte SGEO header, parsed."""
+
+    version: int
+    primitive_type: int
+    flags: Flags
+    units_code: int
+    crc: int
+
+    @property
+    def units(self) -> Optional[str]:
+        return get_unit_from_encoding(self.units_code)
+
+    @property
+    def primitive(self) -> Optional[PrimitiveType]:
+        """The primitive as an enum member, or ``None`` for an unknown code."""
+        try:
+            return PrimitiveType(self.primitive_type)
+        except ValueError:
+            return None
+
+
+@dataclass
+class DecodedMesh:
+    """A mesh's raw SGEO arrays, in Speckle's flat layout.
+
+    ``faces`` is the flat ``[n, i0..in-1, n, i0..]`` face list, matching
+    ``Mesh.faces``; ``vertices``/``vertexNormals`` are flat xyz triples and
+    ``textureCoordinates`` flat uv pairs.
+    """
+
+    vertices: List[float]
+    faces: List[int]
+    vertex_normals: List[float]
+    texture_coordinates: List[float]
+    colors: List[int]
+    units: Optional[str]
+
+
+def decode_header(blob: bytes) -> SgeoHeader:
+    """Parse the 16-byte header without touching the body.
+
+    Lets a caller dispatch on primitive type (or skip a blob it cannot handle)
+    before paying for a full decode.
+    """
+    if len(blob) < HEADER_SIZE:
+        raise SgeoDecodeError(
+            f"SGEO blob is {len(blob)} bytes, shorter than the "
+            f"{HEADER_SIZE}-byte header."
+        )
+    if blob[0:4] != MAGIC:
+        raise SgeoDecodeError(f"Bad SGEO magic {blob[0:4]!r}, expected {MAGIC!r}.")
+    version = blob[4]
+    if version != VERSION_1:
+        raise SgeoDecodeError(
+            f"Unsupported SGEO version {version}, expected {VERSION_1}."
+        )
+    flags_raw, units_code, _reserved, crc = struct.unpack_from("<HHHI", blob, 6)
+    return SgeoHeader(
+        version=version,
+        primitive_type=blob[5],
+        flags=Flags(flags_raw),
+        units_code=units_code,
+        crc=crc,
+    )
+
+
+def verify_crc(blob: bytes) -> None:
+    """Raise when the stored CRC does not match the body bytes.
+
+    Cheap (one zlib call), and the only integrity check the format carries — a
+    truncated download otherwise surfaces as garbage coordinates rather than an
+    error.
+    """
+    header = decode_header(blob)
+    actual = crc32(blob[HEADER_SIZE:])
+    if actual != header.crc:
+        raise SgeoDecodeError(
+            f"SGEO CRC mismatch: header says {header.crc:#010x}, "
+            f"body hashes to {actual:#010x}."
+        )
+
+
+def decode_mesh(blob: bytes, *, verify: bool = True) -> DecodedMesh:
+    """Decode a MESH blob into its raw arrays.
+
+    Mirrors :func:`_encode_mesh` byte for byte, including its two asymmetric
+    alignment rules: normals and UVs are each preceded by a pad to the next
+    8-byte boundary, colours are **not**.
+
+    Only ``vertex_count`` and ``face_count`` are stored, so the optional array
+    lengths are derived from the vertex count (3 per vertex for normals, 2 for
+    UVs, 1 for colours) — the format has no room for anything else.
+    """
+    header = decode_header(blob)
+    if header.primitive_type != PrimitiveType.MESH:
+        primitive = header.primitive
+        name = primitive.name if primitive else f"code {header.primitive_type}"
+        raise SgeoDecodeError(f"Expected a MESH blob, got {name}.")
+    if verify:
+        verify_crc(blob)
+
+    body = memoryview(blob)[HEADER_SIZE:]
+    vertex_count, face_count = struct.unpack_from("<II", body, 0)
+
+    offset = 8
+    vertices, offset = _read_f64_array(body, offset, vertex_count * 3, "vertices")
+    faces, offset = _read_i32_array(body, offset, face_count, "faces")
+
+    normals: List[float] = []
+    if header.flags & Flags.HAS_NORMALS:
+        offset = _align8(offset)
+        normals, offset = _read_f64_array(body, offset, vertex_count * 3, "normals")
+
+    uvs: List[float] = []
+    if header.flags & Flags.HAS_UVS:
+        offset = _align8(offset)
+        uvs, offset = _read_f64_array(body, offset, vertex_count * 2, "UVs")
+
+    colors: List[int] = []
+    if header.flags & Flags.HAS_COLORS:
+        # No pad before colours — mirrors the encoder's documented asymmetry.
+        colors, offset = _read_i32_array(body, offset, vertex_count, "colors")
+
+    return DecodedMesh(
+        vertices=vertices,
+        faces=faces,
+        vertex_normals=normals,
+        texture_coordinates=uvs,
+        colors=colors,
+        units=header.units,
+    )
+
+
+def decode(blob: bytes, *, verify: bool = True) -> Base:
+    """Decode an SGEO v1 blob into the Speckle object it was encoded from.
+
+    The inverse of :func:`encode`. Only MESH is supported so far; every other
+    primitive raises :class:`SgeoDecodeError`.
+    """
+    header = decode_header(blob)
+    if header.primitive_type != PrimitiveType.MESH:
+        primitive = header.primitive
+        name = primitive.name if primitive else f"code {header.primitive_type}"
+        raise SgeoDecodeError(f"No SGEO decoder for primitive {name} yet.")
+
+    from specklepy.objects.geometry.mesh import Mesh
+
+    mesh = decode_mesh(blob, verify=verify)
+    return Mesh(
+        vertices=mesh.vertices,
+        faces=mesh.faces,
+        vertexNormals=mesh.vertex_normals,
+        textureCoordinates=mesh.texture_coordinates,
+        colors=mesh.colors,
+        units=mesh.units,
+    )
+
+
+# ── low-level body readers ─────────────────────────────────────────────────
+
+
+def _align8(offset: int) -> int:
+    """Skip to the next 8-byte boundary — the read side of :func:`_pad8`."""
+    return offset + (-offset % 8)
+
+
+def _ensure_available(body: memoryview, offset: int, size: int, label: str) -> None:
+    if offset + size > len(body):
+        raise SgeoDecodeError(
+            f"SGEO body truncated reading {label}: need {size} bytes at offset "
+            f"{offset}, only {max(0, len(body) - offset)} remain."
+        )
+
+
+def _read_f64_array(
+    body: memoryview, offset: int, count: int, label: str
+) -> Tuple[List[float], int]:
+    if count == 0:
+        return [], offset
+    size = count * 8
+    _ensure_available(body, offset, size, label)
+    values = list(struct.unpack_from(f"<{count}d", body, offset))
+    return values, offset + size
+
+
+def _read_i32_array(
+    body: memoryview, offset: int, count: int, label: str
+) -> Tuple[List[int], int]:
+    """Read ``count`` signed 32-bit words.
+
+    Signed on the way out even though the encoder packs unsigned: ``Mesh.colors``
+    holds signed ARGB ints, and face indices never exceed int32 anyway, so
+    signed is the layout that round-trips.
+    """
+    if count == 0:
+        return [], offset
+    size = count * 4
+    _ensure_available(body, offset, size, label)
+    values = list(struct.unpack_from(f"<{count}i", body, offset))
+    return values, offset + size

--- a/src/specklepy/bundle/sgeo.py
+++ b/src/specklepy/bundle/sgeo.py
@@ -720,8 +720,10 @@ def _decode_polycurve(header: SgeoHeader, r: _Reader) -> Base:
     for _ in range(count):
         length = r.u32()
         r.u32()  # reserved
-        # each segment is a complete nested SGEO blob, CRC included
-        segments.append(decode(r.blob(length)))
+        # each segment is a complete nested SGEO blob whose bytes (CRC field
+        # included) the outer body CRC already covers, so never re-verify —
+        # the same handoff decode() makes for MESH via decode_mesh
+        segments.append(decode(r.blob(length), verify=False))
         r.align8()
     return Polycurve(segments=segments, units=header.units)
 

--- a/tests/bundle/test_pipeline.py
+++ b/tests/bundle/test_pipeline.py
@@ -41,7 +41,11 @@ def test_pipeline_full_bundle(tmp_path):
         p.display_instance(obj_k, inst_k, 0)
 
         mat_k = p.add_material(
-            "mat-1", argb=-1, opacity=1.0, metalness=0.0, roughness=0.5,
+            "mat-1",
+            argb=-1,
+            opacity=1.0,
+            metalness=0.0,
+            roughness=0.5,
             name="Concrete",
         )
         p.has_material(geo_k, mat_k)

--- a/tests/bundle/test_pipeline.py
+++ b/tests/bundle/test_pipeline.py
@@ -41,7 +41,8 @@ def test_pipeline_full_bundle(tmp_path):
         p.display_instance(obj_k, inst_k, 0)
 
         mat_k = p.add_material(
-            "mat-1", argb=-1, opacity=1.0, metalness=0.0, roughness=0.5
+            "mat-1", argb=-1, opacity=1.0, metalness=0.0, roughness=0.5,
+            name="Concrete",
         )
         p.has_material(geo_k, mat_k)
 
@@ -95,3 +96,10 @@ def test_pipeline_full_bundle(tmp_path):
         f"SELECT subtype, name FROM {g}.envelope.nodes.parquet') WHERE id = {sys_k}"
     ).fetchone()
     assert sub == ("System", "Hot Water")
+
+    # the material node retains the source material's display name
+    mat = con.execute(
+        f"SELECT name, argb, roughness FROM {g}.envelope.nodes.parquet') "
+        f"WHERE id = {mat_k}"
+    ).fetchone()
+    assert mat == ("Concrete", -1, 0.5)

--- a/tests/bundle/test_sgeo.py
+++ b/tests/bundle/test_sgeo.py
@@ -606,3 +606,19 @@ def test_decode_polycurve_nests():
     decoded = sgeo.decode(sgeo.encode(Polycurve(segments=[inner, _line()], units="m")))
     assert len(decoded.segments) == 2
     assert len(decoded.segments[0].segments) == 1
+
+
+def test_decode_polycurve_honours_verify_false():
+    from specklepy.objects.geometry.polycurve import Polycurve
+
+    blob = bytearray(sgeo.encode(Polycurve(segments=[_line()], units="m")))
+    # corrupt the nested segment's stored CRC (its header starts at the second
+    # magic; the CRC field sits at header offset 0x0C)
+    inner = bytes(blob).index(sgeo.MAGIC, 4)
+    blob[inner + 12] ^= 0xFF
+    # verify=False must skip CRC checks for nested segments too
+    decoded = sgeo.decode(bytes(blob), verify=False)
+    assert len(decoded.segments) == 1
+    # while verify=True still catches the corruption via the outer body CRC
+    with pytest.raises(sgeo.SgeoDecodeError, match="CRC mismatch"):
+        sgeo.decode(bytes(blob))

--- a/tests/bundle/test_sgeo.py
+++ b/tests/bundle/test_sgeo.py
@@ -324,18 +324,285 @@ def test_decode_rejects_truncated_body():
         sgeo.decode_mesh(blob[:-8], verify=False)
 
 
-def test_decode_non_mesh_primitive_is_explicit():
-    # Not-yet-implemented must be distinguishable from no-geometry, so the
-    # other primitives raise rather than returning None.
-    from specklepy.objects.geometry.line import Line
+def test_decode_mesh_rejects_a_non_mesh_primitive():
+    # decode_mesh is the raw fast path and is MESH-only; decode() handles the
+    # rest. Feeding it a curve must say so rather than misreading the body.
+    with pytest.raises(sgeo.SgeoDecodeError, match="LINE"):
+        sgeo.decode_mesh(sgeo.encode(_line()))
+
+
+def test_decode_rejects_unknown_primitive_code():
+    blob = bytearray(sgeo.encode(_make_mesh()))
+    blob[5] = 99
+    # the CRC is still valid, so this is purely the primitive check
+    with pytest.raises(sgeo.SgeoDecodeError, match="Unknown SGEO primitive"):
+        sgeo.decode(bytes(blob))
+
+
+# ── per-primitive round trips ──────────────────────────────────────────────
+
+
+def _p(x, y, z):
     from specklepy.objects.geometry.point import Point
 
-    line = Line(
-        start=Point(x=0, y=0, z=0, units="m"),
-        end=Point(x=1, y=1, z=1, units="m"),
+    return Point(x=x, y=y, z=z, units="m")
+
+
+def _v(x, y, z):
+    from specklepy.objects.geometry.vector import Vector
+
+    return Vector(x=x, y=y, z=z, units="m")
+
+
+def _plane():
+    from specklepy.objects.geometry.plane import Plane
+
+    return Plane(
+        origin=_p(1, 2, 3),
+        normal=_v(0, 0, 1),
+        xdir=_v(1, 0, 0),
+        ydir=_v(0, 1, 0),
         units="m",
     )
-    with pytest.raises(sgeo.SgeoDecodeError, match="LINE"):
-        sgeo.decode(sgeo.encode(line))
-    with pytest.raises(sgeo.SgeoDecodeError, match="LINE"):
-        sgeo.decode_mesh(sgeo.encode(line))
+
+
+def _interval(start, end):
+    from specklepy.objects.primitive import Interval
+
+    return Interval(start=start, end=end)
+
+
+def _line():
+    from specklepy.objects.geometry.line import Line
+
+    line = Line(start=_p(0, 0, 0), end=_p(1, 2, 3), units="m")
+    line.domain = _interval(0.0, 3.7)
+    return line
+
+
+def _polyline(values, closed=False):
+    from specklepy.objects.geometry.polyline import Polyline
+
+    polyline = Polyline(value=values, units="m")
+    polyline["closed"] = closed
+    return polyline
+
+
+def test_decode_line_roundtrip():
+    decoded = sgeo.decode(sgeo.encode(_line()))
+    assert (decoded.start.x, decoded.start.y, decoded.start.z) == (0, 0, 0)
+    assert (decoded.end.x, decoded.end.y, decoded.end.z) == (1, 2, 3)
+    assert (decoded.domain.start, decoded.domain.end) == (0.0, 3.7)
+    assert decoded.units == "m"
+
+
+def test_decode_polyline_roundtrip():
+    source = _polyline([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 0.0, 0.0], closed=True)
+    decoded = sgeo.decode(sgeo.encode(source))
+    assert decoded.value == source.value
+    # Polyline has no `closed` field, so the flag comes back as a dynamic member
+    assert decoded["closed"] is True
+
+
+def _curve(rational=True, closed=False):
+    from specklepy.objects.geometry.curve import Curve
+
+    display = _polyline([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 0.0], closed=closed)
+    curve = Curve(
+        degree=3,
+        periodic=False,
+        rational=rational,
+        points=[0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 2.0, 0.0, 0.0, 3.0, 1.0, 0.0],
+        weights=[1.0, 0.5, 0.5, 1.0] if rational else [],
+        knots=[0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        closed=closed,
+        displayValue=display,
+        units="m",
+        bbox=None,
+    )
+    curve.domain = _interval(0.0, 9.0)
+    return curve
+
+
+def test_decode_curve_roundtrip():
+    source = _curve()
+    decoded = sgeo.decode(sgeo.encode(source))
+    assert decoded.degree == 3
+    assert decoded.rational is True
+    assert decoded.points == source.points
+    assert decoded.weights == source.weights
+    assert decoded.knots == source.knots
+    assert (decoded.domain.start, decoded.domain.end) == (0.0, 9.0)
+    # the leading render polyline, whose trailing pad the analytical block
+    # depends on for its alignment
+    assert decoded.displayValue.value == source.displayValue.value
+
+
+def test_decode_curve_without_weights():
+    # weights are on the wire only when RATIONAL is set, and their count is
+    # derived from the control-point count rather than stored
+    decoded = sgeo.decode(sgeo.encode(_curve(rational=False)))
+    assert decoded.rational is False
+    assert decoded.weights == []
+    assert decoded.knots == [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+
+
+def test_decode_curve_closed_flag_follows_the_display_polyline():
+    # The encoder derives CLOSED from displayValue, not from Curve.closed, so
+    # that is what a decode can recover.
+    decoded = sgeo.decode(sgeo.encode(_curve(closed=True)))
+    assert decoded.closed is True
+    assert decoded.displayValue["closed"] is True
+
+
+def test_decode_arc_roundtrip():
+    from specklepy.objects.geometry.arc import Arc
+
+    arc = Arc(
+        plane=_plane(),
+        startPoint=_p(1, 0, 0),
+        midPoint=_p(0, 1, 0),
+        endPoint=_p(-1, 0, 0),
+        units="m",
+    )
+    arc.domain = _interval(0.0, 3.14)
+    decoded = sgeo.decode(sgeo.encode(arc))
+    assert (decoded.midPoint.x, decoded.midPoint.y) == (0, 1)
+    assert (decoded.endPoint.x, decoded.endPoint.y) == (-1, 0)
+    assert (decoded.plane.origin.x, decoded.plane.xdir.x) == (1, 1)
+    assert decoded.domain.end == 3.14
+
+
+def test_decode_circle_recovers_centre_from_the_plane():
+    from specklepy.objects.geometry.circle import Circle
+
+    circle = Circle(plane=_plane(), center=_p(1, 2, 3), radius=5.0, units="m")
+    circle.domain = _interval(0.0, 6.28)
+    decoded = sgeo.decode(sgeo.encode(circle))
+    assert decoded.radius == 5.0
+    # `center` is never written; it is the plane origin by construction, which
+    # here happens to be the same point the source carried
+    assert (decoded.center.x, decoded.center.y, decoded.center.z) == (1, 2, 3)
+
+
+def test_decode_single_point_roundtrip():
+    from specklepy.objects.geometry.point import Point
+
+    decoded = sgeo.decode(sgeo.encode(_p(4, 5, 6)))
+    assert isinstance(decoded, Point)
+    assert (decoded.x, decoded.y, decoded.z) == (4, 5, 6)
+
+
+def test_decode_pointcloud_roundtrip():
+    from specklepy.objects.geometry.point_cloud import PointCloud
+
+    cloud = PointCloud(points=[_p(0, 0, 0), _p(1, 1, 1), _p(2, 2, 2)], units="m")
+    cloud["colors"] = [-1, 255, -16711936]
+    cloud["sizes"] = [1.0, 2.0, 3.0]
+    decoded = sgeo.decode(sgeo.encode(cloud))
+    assert isinstance(decoded, PointCloud)
+    assert [p.x for p in decoded.points] == [0, 1, 2]
+    assert decoded["colors"] == [-1, 255, -16711936]
+    assert decoded["sizes"] == [1.0, 2.0, 3.0]
+
+
+def test_decode_one_point_cloud_comes_back_as_a_point():
+    # A lone Point and a 1-point PointCloud with no extras encode identically,
+    # so the distinction is genuinely unrecoverable. Point is the chosen reading.
+    from specklepy.objects.geometry.point import Point
+    from specklepy.objects.geometry.point_cloud import PointCloud
+
+    cloud = PointCloud(points=[_p(7, 8, 9)], units="m")
+    assert isinstance(sgeo.decode(sgeo.encode(cloud)), Point)
+    # two points is unambiguous
+    two = PointCloud(points=[_p(7, 8, 9), _p(1, 0, 0)], units="m")
+    assert isinstance(sgeo.decode(sgeo.encode(two)), PointCloud)
+
+
+def test_decode_ellipse_roundtrip():
+    from specklepy.objects.geometry.ellipse import Ellipse
+
+    ellipse = Ellipse(plane=_plane(), first_radius=3.0, second_radius=1.5, units="m")
+    ellipse.domain = _interval(0.0, 6.28)
+    decoded = sgeo.decode(sgeo.encode(ellipse))
+    assert (decoded.first_radius, decoded.second_radius) == (3.0, 1.5)
+    assert "trimDomain" not in decoded.get_dynamic_member_names()
+
+
+def test_decode_ellipse_with_trim_domain():
+    from specklepy.objects.geometry.ellipse import Ellipse
+
+    ellipse = Ellipse(plane=_plane(), first_radius=3.0, second_radius=1.5, units="m")
+    ellipse.domain = _interval(0.0, 6.28)
+    ellipse["trimDomain"] = _interval(1.0, 2.0)
+    decoded = sgeo.decode(sgeo.encode(ellipse))
+    assert (decoded["trimDomain"].start, decoded["trimDomain"].end) == (1.0, 2.0)
+
+
+def test_decode_spiral_roundtrip():
+    from specklepy.objects.geometry.spiral import Spiral
+
+    spiral = Spiral(
+        start_point=_p(0, 0, 0),
+        end_point=_p(0, 0, 10),
+        plane=_plane(),
+        turns=3.0,
+        pitch=1.2,
+        pitch_axis=_v(0, 0, 1),
+        units="m",
+    )
+    spiral.domain = _interval(0.0, 1.0)
+    spiral["spiralType"] = 2
+    spiral["displayValue"] = _polyline([0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+    decoded = sgeo.decode(sgeo.encode(spiral))
+    assert decoded.turns == 3.0
+    assert decoded.pitch == 1.2
+    assert decoded.pitch_axis.z == 1
+    assert decoded["spiralType"] == 2
+    assert decoded["displayValue"].value == [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+
+
+def test_decode_box_roundtrip():
+    from specklepy.objects.geometry.box import Box
+
+    box = Box(
+        basePlane=_plane(),
+        xSize=_interval(0.0, 1.0),
+        ySize=_interval(0.0, 2.0),
+        zSize=_interval(-1.0, 3.0),
+        units="m",
+    )
+    decoded = sgeo.decode(sgeo.encode(box))
+    assert (decoded.xSize.end, decoded.ySize.end) == (1.0, 2.0)
+    assert (decoded.zSize.start, decoded.zSize.end) == (-1.0, 3.0)
+    assert decoded.basePlane.origin.y == 2
+
+
+def test_decode_polycurve_roundtrip():
+    from specklepy.objects.geometry.arc import Arc
+    from specklepy.objects.geometry.polycurve import Polycurve
+
+    arc = Arc(
+        plane=_plane(),
+        startPoint=_p(1, 0, 0),
+        midPoint=_p(0, 1, 0),
+        endPoint=_p(-1, 0, 0),
+        units="m",
+    )
+    arc.domain = _interval(0.0, 3.14)
+    source = Polycurve(segments=[_line(), arc], units="m")
+    decoded = sgeo.decode(sgeo.encode(source))
+    assert len(decoded.segments) == 2
+    # each segment is a whole nested SGEO blob, 8-aligned after its length
+    assert (decoded.segments[0].end.x, decoded.segments[0].end.z) == (1, 3)
+    assert isinstance(decoded.segments[1], Arc)
+    assert decoded.segments[1].endPoint.x == -1
+
+
+def test_decode_polycurve_nests():
+    from specklepy.objects.geometry.polycurve import Polycurve
+
+    inner = Polycurve(segments=[_line()], units="m")
+    decoded = sgeo.decode(sgeo.encode(Polycurve(segments=[inner, _line()], units="m")))
+    assert len(decoded.segments) == 2
+    assert len(decoded.segments[0].segments) == 1

--- a/tests/bundle/test_sgeo.py
+++ b/tests/bundle/test_sgeo.py
@@ -199,3 +199,143 @@ def test_pad8_alignment_when_faces_misaligned():
 def test_encode_unknown_raises():
     with pytest.raises(ValueError):
         sgeo.encode(object())
+
+
+# ── decoding ───────────────────────────────────────────────────────────────
+
+
+def test_decode_header_roundtrips_metadata():
+    header = sgeo.decode_header(sgeo.encode(_make_mesh(units="mm")))
+    assert header.version == sgeo.VERSION_1
+    assert header.primitive is sgeo.PrimitiveType.MESH
+    assert header.units_code == 1
+    assert header.units == "mm"
+    assert header.flags == sgeo.Flags.NONE
+
+
+def test_get_unit_from_encoding_inverts_the_encoder():
+    for unit in ("mm", "cm", "m", "km", "in", "ft", "yd", "mi"):
+        assert sgeo.get_unit_from_encoding(sgeo.get_encoding_from_unit(unit)) == unit
+    # 0 is the catch-all the encoder maps every unrecognised string to, so it
+    # cannot decode back to a specific unit.
+    assert sgeo.get_unit_from_encoding(0) is None
+
+
+def test_decode_mesh_roundtrip_minimal():
+    mesh = _make_mesh()
+    decoded = sgeo.decode_mesh(sgeo.encode(mesh))
+    assert decoded.vertices == mesh.vertices
+    assert decoded.faces == mesh.faces
+    assert decoded.units == "m"
+    assert decoded.vertex_normals == []
+    assert decoded.texture_coordinates == []
+    assert decoded.colors == []
+
+
+def test_decode_mesh_roundtrip_normals_and_colors():
+    # The aligned case: 3 vertices + 4 faces leaves the body 8-aligned, so the
+    # pad before normals is a no-op and colours follow with no pad at all.
+    colors = [-1, -16711936, 255]
+    mesh = _make_mesh(vertexNormals=[0.0, 0.0, 1.0] * 3, colors=colors)
+    decoded = sgeo.decode_mesh(sgeo.encode(mesh))
+    assert decoded.vertex_normals == [0.0, 0.0, 1.0] * 3
+    # signed on the way out, matching Mesh.colors' signed ARGB ints
+    assert decoded.colors == colors
+
+
+def test_decode_mesh_roundtrip_skips_pad_before_normals():
+    # 5 face ints leave the body at 4 mod 8, so the decoder must skip the same
+    # 4 pad bytes the encoder wrote or every normal reads shifted.
+    mesh = _make_mesh(
+        faces=[4, 0, 1, 2, 3],
+        vertexNormals=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+    )
+    decoded = sgeo.decode_mesh(sgeo.encode(mesh))
+    assert decoded.faces == [4, 0, 1, 2, 3]
+    assert decoded.vertex_normals == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+
+def test_decode_mesh_roundtrip_all_optional_arrays():
+    mesh = _make_mesh(
+        faces=[4, 0, 1, 2, 3],
+        vertexNormals=[1.0] * 9,
+        textureCoordinates=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        colors=[7, 8, 9],
+    )
+    decoded = sgeo.decode_mesh(sgeo.encode(mesh))
+    assert decoded.vertex_normals == [1.0] * 9
+    assert decoded.texture_coordinates == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert decoded.colors == [7, 8, 9]
+
+
+def test_decode_mesh_roundtrip_uvs_without_normals():
+    # UVs carry their own pad, independent of whether normals were written.
+    mesh = _make_mesh(
+        faces=[4, 0, 1, 2, 3], textureCoordinates=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    )
+    decoded = sgeo.decode_mesh(sgeo.encode(mesh))
+    assert decoded.texture_coordinates == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert decoded.vertex_normals == []
+
+
+def test_decode_returns_a_mesh():
+    decoded = sgeo.decode(sgeo.encode(_make_mesh(units="ft")))
+    assert isinstance(decoded, Mesh)
+    assert decoded.units == "ft"
+    assert decoded.faces == [3, 0, 1, 2]
+    assert decoded.vertices == [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+
+
+def test_decode_rejects_corrupt_body():
+    blob = bytearray(sgeo.encode(_make_mesh()))
+    blob[sgeo.HEADER_SIZE + 8] ^= 0xFF  # flip a bit inside the first vertex
+    with pytest.raises(sgeo.SgeoDecodeError, match="CRC mismatch"):
+        sgeo.decode_mesh(bytes(blob))
+
+
+def test_decode_skips_crc_when_asked():
+    blob = bytearray(sgeo.encode(_make_mesh()))
+    blob[sgeo.HEADER_SIZE + 8] ^= 0xFF
+    # verify=False is for callers that already checksummed the transport
+    sgeo.decode_mesh(bytes(blob), verify=False)
+
+
+def test_decode_rejects_bad_magic():
+    with pytest.raises(sgeo.SgeoDecodeError, match="magic"):
+        sgeo.decode_header(b"NOPE" + bytes(12))
+
+
+def test_decode_rejects_short_blob():
+    with pytest.raises(sgeo.SgeoDecodeError, match="shorter than"):
+        sgeo.decode_header(b"SGEO")
+
+
+def test_decode_rejects_unsupported_version():
+    blob = bytearray(sgeo.encode(_make_mesh()))
+    blob[4] = 2
+    with pytest.raises(sgeo.SgeoDecodeError, match="version"):
+        sgeo.decode_header(bytes(blob))
+
+
+def test_decode_rejects_truncated_body():
+    blob = sgeo.encode(_make_mesh())
+    with pytest.raises(sgeo.SgeoDecodeError, match="truncated"):
+        # verify=False so we hit the length check, not the CRC
+        sgeo.decode_mesh(blob[:-8], verify=False)
+
+
+def test_decode_non_mesh_primitive_is_explicit():
+    # Not-yet-implemented must be distinguishable from no-geometry, so the
+    # other primitives raise rather than returning None.
+    from specklepy.objects.geometry.line import Line
+    from specklepy.objects.geometry.point import Point
+
+    line = Line(
+        start=Point(x=0, y=0, z=0, units="m"),
+        end=Point(x=1, y=1, z=1, units="m"),
+        units="m",
+    )
+    with pytest.raises(sgeo.SgeoDecodeError, match="LINE"):
+        sgeo.decode(sgeo.encode(line))
+    with pytest.raises(sgeo.SgeoDecodeError, match="LINE"):
+        sgeo.decode_mesh(sgeo.encode(line))


### PR DESCRIPTION
## Description & motivation

Adds receive-side decoding for every SGEO primitive emitted by the bundle encoder, and preserves material display names so consumers can distinguish materials with identical render values.

## Changes:

- Add SGEO header/CRC validation and primitive decoders, including a raw mesh fast path.
- Pass IFC material names into bundle MATERIAL nodes.
- Add focused decoder and pipeline tests.

## Validation of changes:

- `uv run pytest tests/bundle/test_sgeo.py tests/bundle/test_pipeline.py` (42 passed)
- `uv run ruff check` on all changed Python files

## Checklist:

- [x] My pull request does not duplicate another open pull request for this update.
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated relevant documentation.