### PR TITLE
chore(ENG-9225): mark ModelIngestionResource.complete (completeWithVersion) deprecated

### DIFF
--- a/src/specklepy/api/resources/current/model_ingestion_resource.py
+++ b/src/specklepy/api/resources/current/model_ingestion_resource.py
@@ -1,3 +1,5 @@
+from deprecated import deprecated
+
 from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionCancelledInput,
     ModelIngestionCreateInput,
@@ -12,6 +14,9 @@ from specklepy.core.api.models.current import (
 )
 from specklepy.core.api.resources import (
     ModelIngestionResource as CoreResource,
+)
+from specklepy.core.api.resources.current.model_ingestion_resource import (
+    COMPLETE_WITH_VERSION_DEPRECATION,
 )
 from specklepy.logging import metrics
 
@@ -44,6 +49,7 @@ class ModelIngestionResource(CoreResource):
         metrics.track(metrics.SDK, self.account, {"name": "Ingestion Update"})
         return super().requeue(input)
 
+    @deprecated(**COMPLETE_WITH_VERSION_DEPRECATION)
     def complete(self, input: ModelIngestionSuccessInput) -> str:
         metrics.track(metrics.SDK, self.account, {"name": "Ingestion End"})
         return super().complete(input)

--- a/src/specklepy/core/api/resources/current/model_ingestion_resource.py
+++ b/src/specklepy/core/api/resources/current/model_ingestion_resource.py
@@ -1,5 +1,6 @@
 from typing import Any, Tuple
 
+from deprecated import deprecated
 from gql import Client, gql
 
 from specklepy.api.credentials import Account
@@ -20,6 +21,16 @@ from specklepy.core.api.resource import ResourceBase
 from specklepy.core.api.responses import DataResponse
 
 NAME = "ingestion"
+
+COMPLETE_WITH_VERSION_DEPRECATION: dict[str, Any] = {
+    "reason": (
+        "The completeWithVersion mutation bypasses the v2 REST uploads/complete"
+        " seam, so the server never dispatches dat generation and the created"
+        " version is not viewer-consumable in the bundle era. Complete uploads"
+        " via specklepy.bundle.upload.ArtifactPipeline"
+        " (the v2 REST uploads/complete flow) instead."
+    ),
+}
 
 
 class ModelIngestionResource(ResourceBase):
@@ -234,6 +245,7 @@ class ModelIngestionResource(ResourceBase):
             DataResponse[DataResponse[DataResponse[ModelIngestion]]], QUERY, variables
         ).data.data.data
 
+    @deprecated(**COMPLETE_WITH_VERSION_DEPRECATION)
     def complete(self, input: ModelIngestionSuccessInput) -> str:
         """
         Request that the server completes the ingestion by creating a version


### PR DESCRIPTION
## Why

specklepy twin of the sharp-sdk `[Obsolete]` marking ([ENG-9221](https://linear.app/speckle/issue/ENG-9221)) following the server-side GraphQL deprecation ([ENG-8970](https://linear.app/speckle/issue/ENG-8970)): `completeWithVersion` bypasses the v2 REST `uploads/complete` seam where the server dispatches dat-generation, so versions created through it are not viewer-consumable in the bundle era.

Closes [ENG-9225](https://linear.app/speckle/issue/ENG-9225).

## What

- `@deprecated` (the `deprecated` package, already a dependency) on `ModelIngestionResource.complete` in both the core resource and the metrics-tracking api-layer wrapper, sharing one module-level reason constant — the same pattern as the in-flight file-upload deprecation branch.
- The message names `specklepy.bundle.upload.ArtifactPipeline` (the v2 REST `uploads/complete` flow) as the replacement.
- Warning only — the method stays for deployed packfile-era callers.

## Verification

- Smoke-tested that calling `complete` emits a `DeprecationWarning` carrying the full replacement message.
- `ruff check` and `ruff format --check` pass on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)