### PR TITLE
fix(bundle): re-vendor bundle-spec 1.0.0 (schema_version 1) + nodes.gh_topology arity

### DIFF
--- a/src/specklepy/bundle/envelope_writer.py
+++ b/src/specklepy/bundle/envelope_writer.py
@@ -119,6 +119,7 @@ class EnvelopeWriter:
         *,
         emissive: int | None = None,
         ior: float | None = None,
+        gh_topology: str | None = None,
     ) -> None:
         """Append one value-node. Only the columns relevant to ``kind`` are non-null.
 
@@ -127,6 +128,8 @@ class EnvelopeWriter:
         — in the PARQUET row they sit BETWEEN ``roughness`` and ``elevation``.
         ``emissive`` is a packed ARGB; NULL = no emission (consumers default to
         black). ``ior`` is the PBR index of refraction; NULL = unset.
+        ``gh_topology`` (CONTAINER only) is the Grasshopper collection topology
+        string (e.g. ``"0-1 0;0-1"``) preserved for receive; NULL for everything else.
         """
         self._ensure_not_completed()
         # Row is in spec column order (BY_TABLE["nodes"]); the writer raises if the
@@ -148,6 +151,7 @@ class EnvelopeWriter:
             emissive,
             ior,
             elevation,
+            gh_topology,
         )
 
     def add_scene_view(self, view: SceneView) -> None:

--- a/src/specklepy/bundle/spec/BUNDLE_SPEC_PIN.json
+++ b/src/specklepy/bundle/spec/BUNDLE_SPEC_PIN.json
@@ -1,7 +1,7 @@
 {
   "name": "@speckle/bundle-spec",
-  "version": "5.0.0",
-  "schemaVersion": 5,
-  "specHash": "sha256:8ee6ef5b115721e62b9bea6b1ec0267e2d7ee35910d94ddc37ddb71beac4df31",
-  "note": "Provenance of the vendored bundle_spec.py + bundle_schemas.py. Enforced by speckle-bundle-spec `npm run verify-pin -- --python <this dir>` (CI drift guard). Re-vendor: copy generated/python/*.py from the matching bundle-spec version + update this file."
+  "version": "1.0.0",
+  "schemaVersion": 1,
+  "specHash": "sha256:97be40f54de158c9c888f762f45940a07882c4f384b3ab6be639abf9ee6e995b",
+  "note": "Provenance of the vendored bundle_spec.py + bundle_schemas.py + bundle_cols.py. Enforced by speckle-bundle-spec `npm run verify-pin -- --python <this dir>` (CI drift guard). Re-vendor: copy generated/python/*.py from the matching bundle-spec version + update this file."
 }

--- a/src/specklepy/bundle/spec/bundle_cols.py
+++ b/src/specklepy/bundle/spec/bundle_cols.py
@@ -1,0 +1,193 @@
+# GENERATED FROM spec/bundle-spec.sql — DO NOT EDIT.
+# Run `npm run generate` (or node codegen/generate-all.mjs) to refresh.
+"""Column index of every produced table's parquet field, in spec order (matches
+the bundle_schemas.BY_TABLE descriptor order 1:1). One class per table; use these
+instead of hard-coded ordinals so a spec column insertion shifts writers
+automatically and a rename/removal fails their imports.
+"""
+
+class CAMERA_VIEWS:
+    """Column indices of the camera_views table (spec order)."""
+
+    VIEW = 0
+    NAME = 1
+    IS_DEFAULT = 2
+    ORD = 3
+    POS_X = 4
+    POS_Y = 5
+    POS_Z = 6
+    FORWARD_X = 7
+    FORWARD_Y = 8
+    FORWARD_Z = 9
+    UP_X = 10
+    UP_Y = 11
+    UP_Z = 12
+    TARGET_X = 13
+    TARGET_Y = 14
+    TARGET_Z = 15
+    UNITS = 16
+    IS_ORTHO = 17
+    FOV = 18
+    LENS_MM = 19
+    ORTHO_HEIGHT = 20
+    ASPECT = 21
+    NEAR = 22
+    FAR = 23
+    COLUMN_COUNT = 24
+
+
+class EAV:
+    """Column indices of the eav table (spec order)."""
+
+    OBJECT_INDEX = 0
+    PATH_INDEX = 1
+    VALUE_STRING = 2
+    VALUE_DOUBLE = 3
+    VALUE_BOOLEAN = 4
+    UNIT = 5
+    INTERNAL_DEFINITION_NAME = 6
+    COLUMN_COUNT = 7
+
+
+class GEOMETRIES:
+    """Column indices of the geometries table (spec order)."""
+
+    GEOMETRY_INDEX = 0
+    CONTENT = 1
+    ID = 2
+    TYPE = 3
+    COLUMN_COUNT = 4
+
+
+class MODEL:
+    """Column indices of the model table (spec order)."""
+
+    PATH = 0
+    VALUE_STRING = 1
+    VALUE_DOUBLE = 2
+    VALUE_BOOLEAN = 3
+    UNIT = 4
+    COLUMN_COUNT = 5
+
+
+class NODES:
+    """Column indices of the nodes table (spec order)."""
+
+    ID = 0
+    KIND = 1
+    NAME = 2
+    DEF_REF = 3
+    TRANSFORM = 4
+    UNITS = 5
+    SUBTYPE = 6
+    ARGB = 7
+    OPACITY = 8
+    METALNESS = 9
+    ROUGHNESS = 10
+    EMISSIVE = 11
+    IOR = 12
+    ELEVATION = 13
+    GH_TOPOLOGY = 14
+    COLUMN_COUNT = 15
+
+
+class OBJECT_TYPE:
+    """Column indices of the object_type table (spec order)."""
+
+    OBJECT_INDEX = 0
+    TYPE_INDEX = 1
+    COLUMN_COUNT = 2
+
+
+class OBJECTS:
+    """Column indices of the objects table (spec order)."""
+
+    OBJECT_INDEX = 0
+    APPLICATION_ID = 1
+    COLUMN_COUNT = 2
+
+
+class PATHS:
+    """Column indices of the paths table (spec order)."""
+
+    PATH_INDEX = 0
+    PATH = 1
+    COLUMN_COUNT = 2
+
+
+class PROPERTY_SET_DEFINITIONS:
+    """Column indices of the property_set_definitions table (spec order)."""
+
+    SET_NAME = 0
+    SET_KEY = 1
+    SET_DESCRIPTION = 2
+    FIELD_NAME = 3
+    FIELD_BUCKET_ID = 4
+    DATA_TYPE = 5
+    DEFAULT_STRING = 6
+    DEFAULT_DOUBLE = 7
+    DEFAULT_BOOLEAN = 8
+    UNIT = 9
+    DESCRIPTION = 10
+    APPLIES_TO = 11
+    COLUMN_COUNT = 12
+
+
+class RELATIONS:
+    """Column indices of the relations table (spec order)."""
+
+    REL = 0
+    SRC = 1
+    DST = 2
+    ORD = 3
+    COLUMN_COUNT = 4
+
+
+class SCENE_VIEWS:
+    """Column indices of the scene_views table (spec order)."""
+
+    VIEW = 0
+    NAME = 1
+    IS_DEFAULT = 2
+    ORD = 3
+    SOURCE = 4
+    REF = 5
+    COLUMN_COUNT = 6
+
+
+class STRUCTURAL_RESULTS:
+    """Column indices of the structural_results table (spec order)."""
+
+    OBJECT_INDEX = 0
+    ELEMENT_NAME = 1
+    LOCATION = 2
+    RESULT_TYPE = 3
+    LOAD_CASE = 4
+    COMPONENT = 5
+    POSITION_LABEL = 6
+    STATION = 7
+    STEP = 8
+    VALUE = 9
+    VALUE_TEXT = 10
+    COLUMN_COUNT = 11
+
+
+class TYPE_EAV:
+    """Column indices of the type_eav table (spec order)."""
+
+    TYPE_INDEX = 0
+    PATH_INDEX = 1
+    VALUE_STRING = 2
+    VALUE_DOUBLE = 3
+    VALUE_BOOLEAN = 4
+    UNIT = 5
+    INTERNAL_DEFINITION_NAME = 6
+    COLUMN_COUNT = 7
+
+
+class TYPES:
+    """Column indices of the types table (spec order)."""
+
+    TYPE_INDEX = 0
+    TYPE_KEY = 1
+    COLUMN_COUNT = 2

--- a/src/specklepy/bundle/spec/bundle_schemas.py
+++ b/src/specklepy/bundle/spec/bundle_schemas.py
@@ -59,6 +59,13 @@ BY_TABLE: dict[str, list[ColumnSpec]] = {
         ColumnSpec("id", "string", True),
         ColumnSpec("type", "string", True),
     ],
+    "model": [
+        ColumnSpec("path", "string", False),
+        ColumnSpec("value_string", "string", True),
+        ColumnSpec("value_double", "float64", True),
+        ColumnSpec("value_boolean", "bool", True),
+        ColumnSpec("unit", "string", True),
+    ],
     "nodes": [
         ColumnSpec("id", "int32", False),
         ColumnSpec("kind", "int32", False),
@@ -74,6 +81,7 @@ BY_TABLE: dict[str, list[ColumnSpec]] = {
         ColumnSpec("emissive", "int32", True),
         ColumnSpec("ior", "float64", True),
         ColumnSpec("elevation", "float64", True),
+        ColumnSpec("gh_topology", "string", True),
     ],
     "object_type": [
         ColumnSpec("object_index", "int32", False),
@@ -86,6 +94,20 @@ BY_TABLE: dict[str, list[ColumnSpec]] = {
     "paths": [
         ColumnSpec("path_index", "int32", False),
         ColumnSpec("path", "string", False),
+    ],
+    "property_set_definitions": [
+        ColumnSpec("set_name", "string", False),
+        ColumnSpec("set_key", "string", False),
+        ColumnSpec("set_description", "string", True),
+        ColumnSpec("field_name", "string", False),
+        ColumnSpec("field_bucket_id", "string", True),
+        ColumnSpec("data_type", "string", True),
+        ColumnSpec("default_string", "string", True),
+        ColumnSpec("default_double", "float64", True),
+        ColumnSpec("default_boolean", "bool", True),
+        ColumnSpec("unit", "string", True),
+        ColumnSpec("description", "string", True),
+        ColumnSpec("applies_to", "string", True),
     ],
     "relations": [
         ColumnSpec("rel", "int32", False),

--- a/src/specklepy/bundle/spec/bundle_spec.py
+++ b/src/specklepy/bundle/spec/bundle_spec.py
@@ -1,6 +1,6 @@
 # GENERATED FROM spec/bundle-spec.sql — DO NOT EDIT.
 # Run `npm run generate` (or node codegen/generate-all.mjs) to refresh.
-"""Speckle bundle vocabulary (schema_version 5).
+"""Speckle bundle vocabulary (schema_version 1).
 
 Single source of truth: speckle-bundle-spec/spec/bundle-spec.sql. Regenerate with
 `node codegen/generate-all.mjs` in that repo, then re-vendor into specklepy.
@@ -9,7 +9,7 @@ Single source of truth: speckle-bundle-spec/spec/bundle-spec.sql. Regenerate wit
 from enum import IntEnum
 from typing import NamedTuple, Optional
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 1
 
 
 class Rel(IntEnum):
@@ -29,9 +29,16 @@ class Rel(IntEnum):
     IN_ROOM = 12
     IN_SYSTEM = 14
     IN_GROUP = 17
+    IN_ASSEMBLY = 18
     CONNECTS_TO = 21
     HOSTED_ON = 22
     BOUNDS = 23
+    PLACES = 24
+    DEFINES_MEMBER = 25
+    OBJECT_HAS_MATERIAL = 26
+    OBJECT_HAS_COLOR = 27
+    NODE_HAS_MATERIAL = 28
+    NODE_HAS_COLOR = 29
 
 
 class NodeKind(IntEnum):
@@ -65,11 +72,11 @@ class NodeKindRow(NamedTuple):
 # shipped in the bundle as the self-describing rel_types / node_kinds tables.
 REL_TYPES: list[RelTypeRow] = [
     RelTypeRow(1, "DISPLAY", "object", "geometry", "live", "ordinal"),
-    RelTypeRow(2, "SOLID", "object", "geometry", "reserved", "ordinal"),
+    RelTypeRow(2, "SOLID", "object", "geometry", "live", "ordinal"),
     RelTypeRow(3, "SUBELEMENT", "object", "object", "live", "ordinal"),
-    RelTypeRow(4, "DEFINES", "node", "geometry", "live", None),
-    RelTypeRow(5, "HAS_MATERIAL", "geometry|instance", "node", "live", None),
-    RelTypeRow(6, "HAS_COLOR", "geometry|object", "node", "live", None),
+    RelTypeRow(4, "DEFINES", "node", "geometry", "live", "ordinal"),
+    RelTypeRow(5, "HAS_MATERIAL", "geometry", "node", "live", None),
+    RelTypeRow(6, "HAS_COLOR", "geometry", "node", "live", None),
     RelTypeRow(7, "ON_LEVEL", "object", "node", "live", None),
     RelTypeRow(8, "DISPLAY_INSTANCE", "object", "node", "live", "ordinal"),
     RelTypeRow(9, "DEFINES_INSTANCE", "node", "node", "live", "ordinal"),
@@ -81,12 +88,18 @@ REL_TYPES: list[RelTypeRow] = [
     RelTypeRow(15, "IN_NETWORK", None, None, "retired", None),
     RelTypeRow(16, "IN_LINE", None, None, "retired", None),
     RelTypeRow(17, "IN_GROUP", "object", "node", "live", None),
-    RelTypeRow(18, "IN_ASSEMBLY", None, None, "retired", None),
+    RelTypeRow(18, "IN_ASSEMBLY", "object", "object", "live", "ordinal"),
     RelTypeRow(19, "IN_SUBASSEMBLY", None, None, "retired", None),
     RelTypeRow(20, "XREF", None, None, "retired", None),
     RelTypeRow(21, "CONNECTS_TO", "object", "object", "live", "scope"),
     RelTypeRow(22, "HOSTED_ON", "object", "object", "live", None),
     RelTypeRow(23, "BOUNDS", "object", "object", "live", None),
+    RelTypeRow(24, "PLACES", "object", "node", "live", None),
+    RelTypeRow(25, "DEFINES_MEMBER", "node", "object", "live", "ordinal"),
+    RelTypeRow(26, "OBJECT_HAS_MATERIAL", "object", "node", "live", None),
+    RelTypeRow(27, "OBJECT_HAS_COLOR", "object", "node", "live", None),
+    RelTypeRow(28, "NODE_HAS_MATERIAL", "node", "node", "live", None),
+    RelTypeRow(29, "NODE_HAS_COLOR", "node", "node", "live", None),
 ]
 
 NODE_KINDS: list[NodeKindRow] = [
@@ -96,5 +109,5 @@ NODE_KINDS: list[NodeKindRow] = [
     NodeKindRow(4, "COLOR", "live", None),
     NodeKindRow(5, "LEVEL", "live", None),
     NodeKindRow(6, "COLLECTION", "retired", None),
-    NodeKindRow(7, "CONTAINER", "live", "Collection,Model,MEP System,Network,Group"),
+    NodeKindRow(7, "CONTAINER", "live", "Collection,Layer,Folder,Model,MEP System,Network,Group"),
 ]

--- a/tests/bundle/test_writers.py
+++ b/tests/bundle/test_writers.py
@@ -14,7 +14,7 @@ from specklepy.bundle.eav_writer import EavWriter
 from specklepy.bundle.envelope_writer import EnvelopeWriter
 from specklepy.bundle.geometries_writer import GeometriesParquetWriter
 from specklepy.bundle.parquet_table_writer import ParquetTableWriter, schema_of
-from specklepy.bundle.spec import BY_TABLE, SCHEMA_VERSION, NodeKind, Rel
+from specklepy.bundle.spec import BY_TABLE, REL_TYPES, SCHEMA_VERSION, NodeKind, Rel
 
 BASE = "test"
 
@@ -74,20 +74,23 @@ def test_envelope_writer_roundtrip_and_catalog(tmp_path):
         f"SELECT schema_version FROM "
         f"read_parquet('{out}/{BASE}.envelope.meta.parquet')",
     )[0:1]
-    assert ver[0] == SCHEMA_VERSION == 5
+    assert ver[0] == SCHEMA_VERSION == 1
 
-    # rel_types catalog: 17 live+reserved (retired absent; 17 IN_GROUP and
-    # 22 HOSTED_ON were un-retired in spec v5)
+    # rel_types catalog: every live+reserved row of the vendored spec, retired absent.
+    # Derived from the vendored catalog so a re-vendor never leaves a stale literal.
+    expected_live = sum(1 for r in REL_TYPES if r.status != "retired")
+    retired_ids = [r.id for r in REL_TYPES if r.status == "retired"]
+    assert expected_live > 0 and retired_ids
     (n_rel,) = _q(
         con,
         f"SELECT count(*) FROM read_parquet('{out}/{BASE}.envelope.rel_types.parquet')",
     )[0]
-    assert n_rel == 17
+    assert n_rel == expected_live
     # retired ids never present
     retired = _q(
         con,
         f"SELECT count(*) FROM read_parquet('{out}/{BASE}.envelope.rel_types.parquet') "
-        "WHERE rel IN (13,15,16,18,19,20)",
+        f"WHERE rel IN ({','.join(str(i) for i in retired_ids)})",
     )[0][0]
     assert retired == 0
 
@@ -107,7 +110,7 @@ def test_envelope_writer_roundtrip_and_catalog(tmp_path):
         f"DESCRIBE SELECT * FROM read_parquet('{out}/{BASE}.envelope.nodes.parquet')",
     )
     assert [d[0] for d in described] == [c.name for c in BY_TABLE["nodes"]]
-    assert len(described) == 14  # v5: 12 + emissive + ior
+    assert len(described) == len(BY_TABLE["nodes"])  # tracks the vendored spec
 
     # nodes + relations content
     nodes = _q(
@@ -214,7 +217,7 @@ def test_add_row_arity_mismatch_names_the_table(tmp_path):
     w = ParquetTableWriter(
         str(tmp_path / "nodes.parquet"), schema_of(BY_TABLE["nodes"]), table="nodes"
     )
-    with pytest.raises(ValueError, match=r"table 'nodes'.*12 values.*14 columns"):
+    with pytest.raises(ValueError, match=r"table 'nodes'.*12 values.*15 columns"):
         # the pre-emissive/ior 12-column row shape
         w.add_row(0, 1, None, None, None, None, None, None, None, None, None, None)
     w.complete()


### PR DESCRIPTION
Re-syncs the vendored bundle spec from [speckle-bundle-spec#22](https://github.com/specklesystems/speckle-bundle-spec/pull/22) (`96c5572`), which renumbers the catalog to **schema_version 1 / package 1.0.0**. Successor to #506.

## Changes
- `src/specklepy/bundle/spec/` — `bundle_spec.py`, `bundle_schemas.py` re-vendored; `bundle_cols.py` now vendored too (it's in the lockfile); `BUNDLE_SPEC_PIN.json` → `1.0.0` / `schemaVersion: 1` / new `specHash`. `npm run verify-pin -- --python` ✓.
- `envelope_writer.add_node` — new keyword-only `gh_topology: str | None = None` (15th `nodes` column, added in spec #15). The old vendored copy predated it, so the row-arity guard from #506 would have refused every `nodes` write against the current spec — this was a latent break, surfaced by the re-vendor.
- `tests/bundle/test_writers.py` — `SCHEMA_VERSION == 1`; the `rel_types` count / retired-id list and the `nodes` column count now derive from the vendored catalog (`REL_TYPES`, `BY_TABLE`) instead of literals (`17`, `14`), so the next re-vendor can't leave them stale.

## Verification
- `pytest tests/bundle` — 51 passed
- `ruff check` / `ruff format --check` clean
- `verify-pin` OK: 3 files match `@speckle/bundle-spec@1.0.0 (schema_version 1)`

Related: speckle-sharp-sdk#551 (same pin on the .NET side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018petCQq4mhdr4dzbqfhLdi
