### PR TITLE
fix(bundle): write meta.schema_version as the spec semver string

### DIFF
--- a/src/specklepy/bundle/envelope_writer.py
+++ b/src/specklepy/bundle/envelope_writer.py
@@ -170,13 +170,14 @@ class EnvelopeWriter:
 
     # Self-describing catalog (SOT §6): rel/kind vocabulary + schema version, from the
     # generated spec catalog (live + reserved rows; retired ids are absent and never
-    # reused). Tiny.
+    # reused). Tiny. schema_version is the spec semver as TEXT (bundle-spec #25): one
+    # string names the vocabulary, so it is never an int column.
     def _write_catalog(self) -> None:
         with ParquetTableWriter(
             self._p("meta.parquet"),
             pa.schema(
                 [
-                    pa.field("schema_version", pa.int32(), nullable=False),
+                    pa.field("schema_version", pa.string(), nullable=False),
                     pa.field("produced_by", pa.string()),
                 ]
             ),

--- a/src/specklepy/bundle/spec/BUNDLE_SPEC_PIN.json
+++ b/src/specklepy/bundle/spec/BUNDLE_SPEC_PIN.json
@@ -1,7 +1,7 @@
 {
   "name": "@speckle/bundle-spec",
   "version": "1.0.0",
-  "schemaVersion": 1,
-  "specHash": "sha256:97be40f54de158c9c888f762f45940a07882c4f384b3ab6be639abf9ee6e995b",
+  "schemaVersion": "1.0.0",
+  "specHash": "sha256:40c15f9150aaee2db6fbf2277b9ed71ec9a0332b145c11adbf4821aa69da5ad4",
   "note": "Provenance of the vendored bundle_spec.py + bundle_schemas.py + bundle_cols.py. Enforced by speckle-bundle-spec `npm run verify-pin -- --python <this dir>` (CI drift guard). Re-vendor: copy generated/python/*.py from the matching bundle-spec version + update this file."
 }

--- a/src/specklepy/bundle/spec/bundle_spec.py
+++ b/src/specklepy/bundle/spec/bundle_spec.py
@@ -1,6 +1,6 @@
 # GENERATED FROM spec/bundle-spec.sql — DO NOT EDIT.
 # Run `npm run generate` (or node codegen/generate-all.mjs) to refresh.
-"""Speckle bundle vocabulary (schema_version 1).
+"""Speckle bundle vocabulary (schema_version 1.0.0).
 
 Single source of truth: speckle-bundle-spec/spec/bundle-spec.sql. Regenerate with
 `node codegen/generate-all.mjs` in that repo, then re-vendor into specklepy.
@@ -9,7 +9,7 @@ Single source of truth: speckle-bundle-spec/spec/bundle-spec.sql. Regenerate wit
 from enum import IntEnum
 from typing import NamedTuple, Optional
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = "1.0.0"
 
 
 class Rel(IntEnum):

--- a/tests/bundle/test_writers.py
+++ b/tests/bundle/test_writers.py
@@ -74,7 +74,7 @@ def test_envelope_writer_roundtrip_and_catalog(tmp_path):
         f"SELECT schema_version FROM "
         f"read_parquet('{out}/{BASE}.envelope.meta.parquet')",
     )[0:1]
-    assert ver[0] == SCHEMA_VERSION == 1
+    assert ver[0] == SCHEMA_VERSION == "1.0.0"
 
     # rel_types catalog: every live+reserved row of the vendored spec, retired absent.
     # Derived from the vendored catalog so a re-vendor never leaves a stale literal.


### PR DESCRIPTION
## Summary
Companion to specklesystems/speckle-bundle-spec#25, which changes `meta.schema_version` from `INTEGER` to a `VARCHAR` carrying the spec package semver (`'1.0.0'`).

SpecklePy currently relies on us copy pasting the bundle spec files and tracking them here in this repo.
Ugly, but Oguzhan says we can fix later.