### PR TITLE
fix(ingestion): forward-compatible model_ingestion.complete (ENG-9403)

### DIFF
--- a/src/speckleifc/__main__.py
+++ b/src/speckleifc/__main__.py
@@ -39,7 +39,7 @@ def cmd_line_import() -> None:
         client.authenticate_with_token(TOKEN)
         project = client.project.get(args.project_id)
 
-        version = open_and_convert_file(
+        version_id = open_and_convert_file(
             args.file_path,
             project,
             args.version_message,
@@ -47,7 +47,7 @@ def cmd_line_import() -> None:
             client,
         )
         with open(args.output_path, "w") as f:
-            json.dump({"success": True, "commitId": version.id}, f)
+            json.dump({"success": True, "commitId": version_id}, f)
     except Exception as e:
         stack_trace = traceback.format_exc()
         error_msg = f"IFC Importer failed with exception:\n{stack_trace}"

--- a/src/speckleifc/main.py
+++ b/src/speckleifc/main.py
@@ -17,7 +17,7 @@ from specklepy.core.api.inputs.model_ingestion_inputs import (
     ModelIngestionSuccessInput,
     SourceDataInput,
 )
-from specklepy.core.api.models.current import Project, Version
+from specklepy.core.api.models.current import Project
 from specklepy.core.api.operations import send
 from specklepy.logging import metrics
 from specklepy.logging.exceptions import SpeckleException
@@ -47,7 +47,7 @@ def open_and_convert_file(
     version_message: str | None,
     model_ingestion_id: str,
     client: SpeckleClient,
-) -> Version:
+) -> str:
     try:
         start = time.time()
         very_start = start
@@ -91,7 +91,7 @@ def open_and_convert_file(
         start = time.time()
 
         if bundle:
-            version = _upload_bundle(
+            version_id = _upload_bundle(
                 client, project, account, model_ingestion_id, data, progress
             )
         else:
@@ -118,9 +118,6 @@ def open_and_convert_file(
                 )
             )
 
-            # needed to query version until ingestion api expands to serve it
-            version = client.version.get(version_id, project.id)
-
         end = time.time()
         print(f"Version committed after: {(end - start):.3f}s")
 
@@ -139,7 +136,7 @@ def open_and_convert_file(
             track_email=True,
         )
 
-        return version
+        return version_id
     except Exception as e:
         stack_trace = traceback.format_exc()
         with contextlib.suppress(Exception):
@@ -155,44 +152,6 @@ def open_and_convert_file(
         raise e
 
 
-def _fetch_pre_allocated_version_id(
-    account, project_id: str, model_ingestion_id: str
-) -> str | None:
-    """Read the ingestion's pre-allocated ``versionId`` (a v2-only top-level field).
-
-    Uses the TOP-LEVEL ``ModelIngestion.versionId``, not the ``versionId`` under
-    ``statusData → ModelIngestionSuccessStatus``: that one is only populated once the
-    ingestion has SUCCEEDED, but we need the id up-front (to name/reference the version
-    before uploading), when the status is still PROCESSING and the success fragment is
-    null.
-
-    Done with a dedicated GraphQL query rather than the shared model_ingestion resource
-    because the top-level ``versionId`` field only exists on servers with the v2 data
-    endpoints — selecting it in the SDK's standard ingestion queries breaks older
-    servers. This runs only on the bundle path (a v2 server), so it is safe here.
-    """
-    import httpx
-
-    url = account.serverInfo.url.rstrip("/") + "/graphql"
-    headers = {"Authorization": f"Bearer {account.token}"} if account.token else {}
-    query = (
-        "query($p:String!,$i:ID!){ project(id:$p){ ingestion(id:$i){ versionId } } }"
-    )
-    resp = httpx.post(
-        url,
-        headers=headers,
-        json={"query": query, "variables": {"p": project_id, "i": model_ingestion_id}},
-        timeout=60,
-    )
-    body = resp.json()
-    if body.get("errors"):
-        raise SpeckleException(
-            f"Failed to fetch pre-allocated version id: {body['errors']}"
-        )
-    ingestion = ((body.get("data") or {}).get("project") or {}).get("ingestion") or {}
-    return ingestion.get("versionId")
-
-
 def _upload_bundle(
     client: SpeckleClient,
     project: Project,
@@ -200,14 +159,14 @@ def _upload_bundle(
     model_ingestion_id: str,
     data,
     progress: IngestionProgressManager,
-) -> Version:
+) -> str:
     """Build the Speckle 4.0 artefact bundle and upload it via the v2 data endpoints.
 
     Opt-in via SPECKLE_IFC_BUNDLE. The version is created server-side by the v2
     ``complete`` call (no v1 ``model_ingestion.complete``).
     """
-    version_id = _fetch_pre_allocated_version_id(
-        account, project.id, model_ingestion_id
+    version_id = client.model_ingestion.get_reserved_version_id(
+        project.id, model_ingestion_id
     )
     if not version_id:
         raise SpeckleException(
@@ -224,5 +183,4 @@ def _upload_bundle(
         ) as pipeline:
             version_id = pipeline.upload_dir(version_id, root_id, child_count)
 
-    # needed to query version until ingestion api expands to serve it
-    return client.version.get(version_id, project.id)
+    return version_id

--- a/src/specklepy/api/resources/current/model_ingestion_resource.py
+++ b/src/specklepy/api/resources/current/model_ingestion_resource.py
@@ -49,6 +49,14 @@ class ModelIngestionResource(CoreResource):
         metrics.track(metrics.SDK, self.account, {"name": "Ingestion Update"})
         return super().requeue(input)
 
+    def get_reserved_version_id(
+        self, project_id: str, model_ingestion_id: str
+    ) -> str | None:
+        metrics.track(
+            metrics.SDK, self.account, {"name": "Ingestion Get Reserved Version Id"}
+        )
+        return super().get_reserved_version_id(project_id, model_ingestion_id)
+
     @deprecated(**COMPLETE_WITH_VERSION_DEPRECATION)
     def complete(self, input: ModelIngestionSuccessInput) -> str:
         metrics.track(metrics.SDK, self.account, {"name": "Ingestion End"})

--- a/src/specklepy/core/api/resources/current/model_ingestion_resource.py
+++ b/src/specklepy/core/api/resources/current/model_ingestion_resource.py
@@ -2,6 +2,7 @@ from typing import Any, Tuple
 
 from deprecated import deprecated
 from gql import Client, gql
+from pydantic import BaseModel, Field
 
 from specklepy.api.credentials import Account
 from specklepy.core.api.inputs.model_ingestion_inputs import (
@@ -19,6 +20,7 @@ from specklepy.core.api.models.current import (
 )
 from specklepy.core.api.resource import ResourceBase
 from specklepy.core.api.responses import DataResponse
+from specklepy.logging.exceptions import SpeckleException
 
 NAME = "ingestion"
 
@@ -31,6 +33,15 @@ COMPLETE_WITH_VERSION_DEPRECATION: dict[str, Any] = {
         " (the v2 REST uploads/complete flow) instead."
     ),
 }
+
+
+class _CompleteStatusData(BaseModel):
+    """statusData fragments selected by `complete`, discriminated by typename."""
+
+    typename: str = Field(alias="__typename")
+    version_id: str | None = Field(default=None, alias="versionId")
+    progress_message: str | None = Field(default=None, alias="progressMessage")
+    error_reason: str | None = Field(default=None, alias="errorReason")
 
 
 class ModelIngestionResource(ResourceBase):
@@ -244,11 +255,55 @@ class ModelIngestionResource(ResourceBase):
             DataResponse[DataResponse[DataResponse[ModelIngestion]]], request
         ).data.data.data
 
+    def get_reserved_version_id(
+        self, project_id: str, model_ingestion_id: str
+    ) -> str | None:
+        """
+        Read the id the server reserved for the version this ingestion will produce.
+
+        Selects the top-level `ModelIngestion.versionId`, which only exists on
+        servers where every version entry point is an ingestion (2026.9+, ENG-9314).
+        On older servers the query fails validation, so only call this when the
+        server has signalled it (see `complete`).
+
+        Returns:
+            str | None -- the reserved version id, None if none was reserved
+        """
+        request = gql(
+            """
+            query IngestionReservedVersionId(
+              $projectId: String!, $modelIngestionId: ID!
+            ) {
+              data:project(id: $projectId) {
+                data:ingestion(id: $modelIngestionId) {
+                  data:versionId
+                }
+              }
+            }
+            """
+        )
+
+        request.variable_values = {
+            "projectId": project_id,
+            "modelIngestionId": model_ingestion_id,
+        }
+
+        return self.make_request_and_parse_response(
+            DataResponse[DataResponse[DataResponse[str | None]]],
+            request,
+        ).data.data.data
+
     @deprecated(**COMPLETE_WITH_VERSION_DEPRECATION)
     def complete(self, input: ModelIngestionSuccessInput) -> str:
         """
-        Request that the server completes the ingestion by creating a version
-        If successful, the job will be in a terminal "successful" state.
+        Request that the server completes the ingestion by creating a version.
+
+        On servers up to 2026.8 the ingestion is in a terminal "successful" state
+        when this returns and the version exists. From server 2026.9 (ENG-9314)
+        the server may answer with the ingestion still processing; in that case
+        the returned id is the one reserved for the version and the version is
+        not visible yet. Callers that need the version to exist should poll
+        `project.modelIngestions` (or `get_ingestion`) for a terminal status.
 
         For failed Ingestions, use `fail_with_error` instead
         For user cancellation, use `fail_with_cancelled` instead
@@ -257,7 +312,10 @@ class ModelIngestionResource(ResourceBase):
             input {ModelIngestionSuccessInput} -- input variable
 
         Returns:
-            str -- the id of the version that was just created to complete the ingestion
+            str -- the id of the version created (or reserved) for this ingestion
+
+        Raises:
+            SpeckleException -- the server reported the ingestion as failed
         """
         request = gql(
             """
@@ -266,8 +324,15 @@ class ModelIngestionResource(ResourceBase):
                 data: modelIngestionMutations {
                   data: completeWithVersion(input: $input) {
                     data:statusData {
+                      __typename
                       ... on ModelIngestionSuccessStatus {
-                        data:versionId
+                        versionId
+                      }
+                      ... on ModelIngestionProcessingStatus {
+                        progressMessage
+                      }
+                      ... on ModelIngestionFailedStatus {
+                        errorReason
                       }
                     }
                   }
@@ -281,10 +346,36 @@ class ModelIngestionResource(ResourceBase):
             "input": input.model_dump(warnings="error", by_alias=True),
         }
 
-        return self.make_request_and_parse_response(
-            DataResponse[DataResponse[DataResponse[DataResponse[DataResponse[str]]]]],
+        status = self.make_request_and_parse_response(
+            DataResponse[DataResponse[DataResponse[DataResponse[_CompleteStatusData]]]],
             request,
-        ).data.data.data.data.data
+        ).data.data.data.data
+
+        if status.typename == "ModelIngestionSuccessStatus":
+            if status.version_id is None:
+                raise SpeckleException(
+                    "Ingestion completed but the server returned no version id"
+                )
+            return status.version_id
+
+        if status.typename == "ModelIngestionProcessingStatus":
+            version_id = self.get_reserved_version_id(
+                input.project_id, input.ingestion_id
+            )
+            if version_id is None:
+                raise SpeckleException(
+                    "Ingestion is still processing and the server reserved no"
+                    " version id"
+                )
+            return version_id
+
+        if status.typename == "ModelIngestionFailedStatus":
+            raise SpeckleException(status.error_reason or "Ingestion failed")
+
+        raise SpeckleException(
+            f"Unexpected ingestion status type from completeWithVersion:"
+            f" {status.typename}"
+        )
 
     def fail_with_error(self, input: ModelIngestionFailedInput) -> ModelIngestion:
         """

--- a/tests/unit/test_model_ingestion_resource.py
+++ b/tests/unit/test_model_ingestion_resource.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from specklepy.core.api.inputs.model_ingestion_inputs import (
+    ModelIngestionSuccessInput,
+)
+from specklepy.core.api.resources.current.model_ingestion_resource import (
+    ModelIngestionResource,
+)
+from specklepy.logging.exceptions import SpeckleException
+
+
+def _resource() -> tuple[ModelIngestionResource, MagicMock]:
+    client = MagicMock()
+    resource = ModelIngestionResource(
+        account=MagicMock(), basepath="", client=client, server_version=None
+    )
+    return resource, client
+
+
+def _complete_response(status_data: dict) -> dict:
+    return {"data": {"data": {"data": {"data": status_data}}}}
+
+
+def _input() -> ModelIngestionSuccessInput:
+    return ModelIngestionSuccessInput(
+        project_id="project-id",
+        ingestion_id="ingestion-id",
+        root_object_id="root-id",
+        version_message=None,
+    )
+
+
+def test_complete_success_returns_version_id_without_follow_up():
+    resource, client = _resource()
+    client.execute.return_value = _complete_response(
+        {"__typename": "ModelIngestionSuccessStatus", "versionId": "version-id"}
+    )
+
+    assert resource.complete(_input()) == "version-id"
+    assert client.execute.call_count == 1
+
+
+def test_complete_processing_fetches_reserved_version_id():
+    resource, client = _resource()
+    client.execute.side_effect = [
+        _complete_response(
+            {
+                "__typename": "ModelIngestionProcessingStatus",
+                "progressMessage": "still going",
+            }
+        ),
+        {"data": {"data": {"data": "reserved-id"}}},
+    ]
+
+    assert resource.complete(_input()) == "reserved-id"
+    assert client.execute.call_count == 2
+    (request,), _ = client.execute.call_args
+    assert request.variable_values == {
+        "projectId": "project-id",
+        "modelIngestionId": "ingestion-id",
+    }
+
+
+def test_complete_processing_without_reserved_id_raises():
+    resource, client = _resource()
+    client.execute.side_effect = [
+        _complete_response({"__typename": "ModelIngestionProcessingStatus"}),
+        {"data": {"data": {"data": None}}},
+    ]
+
+    with pytest.raises(SpeckleException):
+        resource.complete(_input())
+
+
+def test_complete_failed_raises_with_error_reason():
+    resource, client = _resource()
+    client.execute.return_value = _complete_response(
+        {"__typename": "ModelIngestionFailedStatus", "errorReason": "boom"}
+    )
+
+    with pytest.raises(SpeckleException, match="boom"):
+        resource.complete(_input())
+    assert client.execute.call_count == 1


### PR DESCRIPTION
Linear: [ENG-9403](https://linear.app/speckle/issue/ENG-9403). Spec: big-truck dev compat §3, ledger entry 10.

## Why

Server 2026.9 ([ENG-9314](https://linear.app/speckle/issue/ENG-9314)) makes every non-bundle version entry point an ingestion. `completeWithVersion` then answers with the ingestion still `processing`, and the version only exists at bundle complete. Today's `complete()` selects only the `ModelIngestionSuccessStatus` fragment, so that answer parses to `None`, pydantic raises, and Blender / speckleifc mark the ingestion failed.

## What

`ModelIngestionResource.complete()` (core + metrics layer; `-> str` and the deprecation are kept, no caller changes):

- mutation selects `__typename` plus the Success / Processing / Failed fragments (all three types exist on both server lines)
- `Success` → `statusData.versionId`, identical to today on 2026.8
- `Processing` → separate `project { ingestion { versionId } }` query for the reserved id, issued only on this branch (the top-level `versionId` field does not exist on 2026.8 and would fail validation if selected in the mutation)
- `Failed` → `SpeckleException(errorReason)`

New `get_reserved_version_id(project_id, ingestion_id)` on the resource replaces speckleifc's raw-httpx `_fetch_pre_allocated_version_id`. Both speckleifc paths drop the `client.version.get` read-back (404s until bundle complete on 2026.9) and `__main__` writes the returned id as `commitId`.

`version.create` untouched.

## Testing

- Unit (`tests/unit/test_model_ingestion_resource.py`, mocked gql client): Success returns the id with no follow-up request; Processing issues exactly one follow-up and returns its id; Processing with no reserved id raises; Failed raises with the reason.
- Integration against a 2026.8 server runs in CI and is the regression that matters (behaviour unchanged).
- The Processing branch can only be exercised by mocks until ENG-9314 lands: a speckle/next server without it still returns Success.

## Release

Shipped as **specklepy 2026.8.1** from the 2026.8.0 base (branch `gergo/eng-9403-release-2026.8.1`, commit `6151267`); this PR is the mainline landing of the same change adapted to gql 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
