### PR TITLE
fix(bundle): v2 upload rail reports apollographql-client-version

### DIFF
--- a/src/specklepy/bundle/upload.py
+++ b/src/specklepy/bundle/upload.py
@@ -21,6 +21,7 @@ from typing import Mapping
 import httpx
 
 from specklepy.api.credentials import Account
+from specklepy.logging import metrics
 
 
 class ArtifactUploadError(Exception):
@@ -56,7 +57,15 @@ class ArtifactPipeline:
         self.output_dir = output_dir
 
         base = account.serverInfo.url.rstrip("/") + "/api/v2/"
-        headers = {"Authorization": f"Bearer {account.token}"} if account.token else {}
+        # The server reads clientAppVersion for envelope-born versions from the
+        # apollographql-client-version header on uploads/complete, mirroring the
+        # GraphQL transport in api/client.py (ENG-9491).
+        headers = {
+            "apollographql-client-name": metrics.HOST_APP,
+            "apollographql-client-version": metrics.HOST_APP_VERSION,
+        }
+        if account.token:
+            headers["Authorization"] = f"Bearer {account.token}"
         self._speckle = httpx.Client(base_url=base, headers=headers, timeout=timeout)
         # presigned S3 PUTs are unauthenticated (the URL carries the signature).
         self._s3 = httpx.Client(timeout=timeout)

--- a/tests/bundle/test_upload.py
+++ b/tests/bundle/test_upload.py
@@ -1,0 +1,78 @@
+"""ArtifactPipeline HTTP contract: sign → presigned PUT → complete against fake
+transports, pinning which headers each rail carries."""
+
+import httpx
+import pytest
+
+from specklepy.api.credentials import Account
+from specklepy.bundle.upload import ArtifactPipeline
+from specklepy.logging import metrics
+
+VERSION_ID = "ver123"
+
+
+@pytest.fixture
+def pipeline(tmp_path):
+    artefact = tmp_path / "bundle.envelope.parquet"
+    artefact.write_bytes(b"parquet-bytes")
+
+    account = Account.from_token("secret-token", "https://speckle.example.org")
+    speckle_requests: list[httpx.Request] = []
+    s3_requests: list[httpx.Request] = []
+
+    def speckle_handler(request: httpx.Request) -> httpx.Response:
+        speckle_requests.append(request)
+        if request.url.path.endswith("/uploads/sign"):
+            return httpx.Response(
+                200,
+                json={
+                    "uploads": {
+                        artefact.name: {"url": "https://s3.example.org/put/bundle"}
+                    }
+                },
+            )
+        if request.url.path.endswith("/uploads/complete"):
+            return httpx.Response(200, json={"versionId": VERSION_ID})
+        raise AssertionError(f"unexpected speckle request: {request.url}")
+
+    def s3_handler(request: httpx.Request) -> httpx.Response:
+        s3_requests.append(request)
+        return httpx.Response(200, headers={"ETag": '"abc"'})
+
+    with ArtifactPipeline(
+        project_id="proj",
+        ingestion_id="ing",
+        version_id=VERSION_ID,
+        account=account,
+        output_dir=str(tmp_path),
+    ) as p:
+        p._speckle._transport = httpx.MockTransport(speckle_handler)
+        p._s3._transport = httpx.MockTransport(s3_handler)
+        result = p.upload_files(
+            {artefact.name: str(artefact)}, root_id="root", total_children_count=1
+        )
+
+    assert result == VERSION_ID
+    return speckle_requests, s3_requests
+
+
+def test_speckle_requests_carry_client_app_headers(pipeline):
+    # The server derives clientAppVersion for envelope-born versions from
+    # these headers on uploads/complete (ENG-9491).
+    speckle_requests, _ = pipeline
+    assert len(speckle_requests) == 2  # sign + complete
+    for request in speckle_requests:
+        assert request.headers["apollographql-client-name"] == metrics.HOST_APP
+        assert (
+            request.headers["apollographql-client-version"] == metrics.HOST_APP_VERSION
+        )
+        assert request.headers["authorization"] == "Bearer secret-token"
+
+
+def test_presigned_s3_put_carries_no_speckle_headers(pipeline):
+    _, s3_requests = pipeline
+    assert len(s3_requests) == 1
+    (put,) = s3_requests
+    assert "apollographql-client-name" not in put.headers
+    assert "apollographql-client-version" not in put.headers
+    assert "authorization" not in put.headers


### PR DESCRIPTION
## Problem

specklepy sends the `apollographql-client-name` / `apollographql-client-version` headers only on its GraphQL transport (`api/client.py`). The v2 bundle upload rail (`bundle/upload.py`) built its Speckle-bound `httpx.Client` with just an Authorization header. The server reads `clientAppVersion` for envelope-born versions from the `apollographql-client-version` header of the v2 `uploads/complete` request and forwards it to the PostHog "Version Created" event, so legacy GraphQL sends reported a populated `clientAppVersion` while bundle sends silently dropped it (null).

## Fix

Add the two headers to the Speckle-bound `httpx.Client` in `ArtifactPipeline`, mirroring the GraphQL transport (`metrics.HOST_APP` / `metrics.HOST_APP_VERSION`). Presigned S3 PUTs go through a separate client and stay free of extra headers, since the presigned URL carries the signature.

This is the client half of speckle-server-internal#2719.

Closes ENG-9491

## Tests

- `tests/bundle/test_upload.py` (new): drives `ArtifactPipeline.upload_files` through fake httpx transports and pins that
  - both Speckle-bound requests (sign + complete) carry `apollographql-client-name`, `apollographql-client-version`, and Authorization
  - the presigned S3 PUT carries none of them
- `uv run pytest tests/bundle` passes (183 passed, 2 skipped), ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReH2YaViKYKboNZXMKNZ6G