### PR TITLE
fix(bundle): escape glob metachars in ArtifactPipeline.upload_dir (FEA-645)

### DIFF
--- a/src/specklepy/bundle/upload.py
+++ b/src/specklepy/bundle/upload.py
@@ -101,7 +101,12 @@ class ArtifactPipeline:
         files = {
             os.path.basename(p): p
             for p in sorted(
-                glob.glob(os.path.join(self.output_dir, f"{base_name}.*.parquet"))
+                # glob.escape: base_name is the source filename stem, and `[a29]`-style
+                # tags are common in BIM deliverables — unescaped they become
+                # character classes and the artefacts are never found (FEA-645).
+                glob.glob(
+                    os.path.join(self.output_dir, f"{glob.escape(base_name)}.*.parquet")
+                )
             )
         }
         if not files:

--- a/tests/bundle/test_upload.py
+++ b/tests/bundle/test_upload.py
@@ -1,6 +1,8 @@
 """ArtifactPipeline HTTP contract: sign → presigned PUT → complete against fake
 transports, pinning which headers each rail carries."""
 
+import json
+
 import httpx
 import pytest
 
@@ -76,3 +78,49 @@ def test_presigned_s3_put_carries_no_speckle_headers(pipeline):
     assert "apollographql-client-name" not in put.headers
     assert "apollographql-client-version" not in put.headers
     assert "authorization" not in put.headers
+
+
+def test_upload_dir_finds_artefacts_when_base_name_has_glob_metachars(tmp_path):
+    """FEA-645: the base name is the source filename stem, and `[a29]`-style tags
+    turn an unescaped glob into a character class — the artefacts were written but
+    never found. The `[a]`-matching decoy proves the match is literal."""
+    base = "Tower [a29] ?rev* v2"
+    (tmp_path / f"{base}.nodes.parquet").write_bytes(b"nodes")
+    (tmp_path / f"{base}.geometries.parquet").write_bytes(b"geo")
+    (tmp_path / "Tower a ?rev* v2.nodes.parquet").write_bytes(b"decoy")
+    signed: list[list[str]] = []
+
+    def speckle_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/uploads/sign"):
+            files = json.loads(request.content)["files"]
+            signed.append(files)
+            return httpx.Response(
+                200,
+                json={
+                    "uploads": {
+                        f: {"url": f"https://s3.example.org/put/{i}"}
+                        for i, f in enumerate(files)
+                    }
+                },
+            )
+        if request.url.path.endswith("/uploads/complete"):
+            return httpx.Response(200, json={"versionId": VERSION_ID})
+        raise AssertionError(f"unexpected speckle request: {request.url}")
+
+    def s3_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"ETag": '"abc"'})
+
+    account = Account.from_token("secret-token", "https://speckle.example.org")
+    with ArtifactPipeline(
+        project_id="proj",
+        ingestion_id="ing",
+        version_id=VERSION_ID,
+        account=account,
+        output_dir=str(tmp_path),
+    ) as p:
+        p._speckle._transport = httpx.MockTransport(speckle_handler)
+        p._s3._transport = httpx.MockTransport(s3_handler)
+        result = p.upload_dir(base, root_id="root", total_children_count=2)
+
+    assert result == VERSION_ID
+    assert signed == [[f"{base}.geometries.parquet", f"{base}.nodes.parquet"]]


### PR DESCRIPTION
Companion to specklesystems/speckle-converters#134 for [FEA-645](https://linear.app/speckle/issue/FEA-645/bundle-upload-fails-to-find-artefact-files-when-the-source-filename).

## What

`ArtifactPipeline.upload_dir` finds the written parquets with `glob.glob(f"{base_name}.*.parquet")`, where `base_name` is the source filename stem. A stem containing `[`, `]`, `*` or `?` (a `[a29]`-style tag is the reported case) becomes a character class, nothing matches, and the upload raises `No artefact files found` after the bundle was written correctly.

`glob.escape(base_name)` makes the match literal. No behaviour change for ordinary names.

## Test

`test_upload_dir_finds_artefacts_when_base_name_has_glob_metachars` uses the stem `Tower [a29] ?rev* v2` plus a decoy the unescaped class *would* have matched, and asserts only the literal files get signed. `tests/bundle` + `tests/unit` green apart from the pre-existing `test_user_application_data_path` env failure, which also fails on main.