### PR TITLE
fix(speckleifc): retry geometry iteration with the contexts 3D representations reference (ENG-9524)

### DIFF
--- a/src/speckleifc/ifc_geometry_processing.py
+++ b/src/speckleifc/ifc_geometry_processing.py
@@ -50,10 +50,68 @@ def open_ifc(file_path: str) -> file:
         raise SpeckleException(f"file at {file_path} is not a compatible ifc file type")
 
 
-def create_geometry_iterator(ifc_file: file | sqlite) -> iterator:
+# RepresentationType values that carry 3D shape (IFC2x3 + IFC4 vocabularies).
+# Curve-only types (Curve2D, GeometricCurveSet, Annotation2D, ...) are deliberately
+# absent: they never yield a solid and must not steer context selection.
+_3D_REPRESENTATION_TYPES = frozenset(
+    t.lower()
+    for t in (
+        "SweptSolid",
+        "AdvancedSweptSolid",
+        "Brep",
+        "AdvancedBrep",
+        "CSG",
+        "Clipping",
+        "SurfaceModel",
+        "SolidModel",
+        "Tessellation",
+        "MappedRepresentation",
+        "SectionedSpine",
+    )
+)
+
+# What IfcOpenShell's own default picks (mapping.cpp,
+# addRepresentationsFromDefaultContexts): top-level contexts of these types, plus
+# their sub-contexts.
+_DEFAULT_CONTEXT_TYPES = frozenset(("model", "design", "model view", "detail view"))
+
+
+def contexts_for_3d_representations(ifc_file: file) -> list[int]:
+    """Context ids IfcOpenShell should read: its own default choice, widened with every
+    context a 3D shape representation actually points at.
+
+    IfcOpenShell selects representations context-first. With the default settings it
+    keeps the Model-family contexts (+ sub-contexts) and only falls back to "all
+    contexts" when those hold *nothing*. Some exporters (ICPrefab/iTConcrete precast
+    files, ENG-9524) attach every Body representation to a *Plan* context; one stray
+    FootPrint curve in a Model sub-context then defeats the fallback and the whole file
+    reads as empty. Building the id set from the representations themselves makes the
+    selection evidence-based while staying a strict superset of the default, so nothing
+    the default converts is lost.
+    """
+    ids: set[int] = set()
+    for context in ifc_file.by_type("IfcGeometricRepresentationContext", False):
+        context_type = (context.ContextType or "").lower()
+        if context_type in _DEFAULT_CONTEXT_TYPES:
+            ids.add(context.id())
+            for sub in context.HasSubContexts or ():
+                ids.add(sub.id())
+    for rep in ifc_file.by_type("IfcShapeRepresentation"):
+        is_3d = (rep.RepresentationType or "").lower() in _3D_REPRESENTATION_TYPES
+        if is_3d and rep.ContextOfItems is not None:
+            ids.add(rep.ContextOfItems.id())
+    return sorted(ids)
+
+
+def create_geometry_iterator(
+    ifc_file: file | sqlite, context_ids: list[int] | None = None
+) -> iterator:
     GEOMETRY_LIBRARY = "hybrid-opencascade-cgal"  # First OCC then fallback to CGAL
+    ifc_settings = _create_iterator_settings()
+    if context_ids:
+        ifc_settings.set("context-ids", context_ids)
     return iterator(
-        _create_iterator_settings(),
+        ifc_settings,
         ifc_file,
         multiprocessing.cpu_count(),
         geometry_library=GEOMETRY_LIBRARY,  # type: ignore

--- a/src/speckleifc/importer.py
+++ b/src/speckleifc/importer.py
@@ -31,7 +31,10 @@ from speckleifc.converter.node import (
     SystemManager,
 )
 from speckleifc.converter.object import Placement, convert_object
-from speckleifc.ifc_geometry_processing import create_geometry_iterator
+from speckleifc.ifc_geometry_processing import (
+    contexts_for_3d_representations,
+    create_geometry_iterator,
+)
 from speckleifc.ifc_openshell_helpers import get_children
 from speckleifc.progress import ProgressReporter
 from specklepy.bundle.builder import (
@@ -120,7 +123,20 @@ class ImportJob:
     def _pre_process_geometry(self) -> None:
         iterator = create_geometry_iterator(self.ifc_file)
         if not iterator.initialize():
-            raise SpeckleException("Failed to find any geometry in file")
+            # The default context-first selection came up empty. Before declaring the
+            # file empty, retry with the contexts the 3D representations actually
+            # reference (ENG-9524: exporters that put Body representations in a Plan
+            # context). A file that converts today never reaches this branch.
+            context_ids = contexts_for_3d_representations(self.ifc_file)
+            if context_ids:
+                logger.warning(
+                    "Default context selection found no geometry; "
+                    "retrying with contexts %s",
+                    context_ids,
+                )
+                iterator = create_geometry_iterator(self.ifc_file, context_ids)
+            if not context_ids or not iterator.initialize():
+                raise SpeckleException("Failed to find any geometry in file")
 
         self.progress.report("Converting geometries", None)
 

--- a/tests/bundle/test_ifc_context_fallback.py
+++ b/tests/bundle/test_ifc_context_fallback.py
@@ -1,0 +1,190 @@
+"""ENG-9524: Body representations filed under a *Plan* context, plus one curve in a
+Model sub-context. IfcOpenShell's default context selection keeps only the Model family
+and, because the sub-context is not empty, never falls back to "all contexts" — the file
+reads as having no geometry. The importer must retry with the contexts the 3D
+representations actually reference (ICPrefab / iTConcrete precast exports)."""
+
+from __future__ import annotations
+
+import pytest
+
+ifcopenshell = pytest.importorskip("ifcopenshell")  # requires the [speckleifc] extra
+
+from speckleifc.ifc_geometry_processing import (  # noqa: E402
+    contexts_for_3d_representations,
+    create_geometry_iterator,
+)
+from speckleifc.importer import ImportJob  # noqa: E402
+
+
+class _NoProgress:
+    def report(self, progress_message: str, progress: float | None) -> None:
+        pass
+
+    def should_report_progress(self) -> bool:
+        return False
+
+
+def _axis(f, origin=(0.0, 0.0, 0.0)):
+    return f.create_entity(
+        "IfcAxis2Placement3D",
+        Location=f.create_entity("IfcCartesianPoint", Coordinates=origin),
+    )
+
+
+def _plan_context_body_file(with_grid: bool):
+    f = ifcopenshell.file(schema="IFC2X3")
+    project = f.create_entity(
+        "IfcProject", GlobalId=ifcopenshell.guid.new(), Name="Precast"
+    )
+    project.UnitsInContext = f.create_entity(
+        "IfcUnitAssignment",
+        Units=[
+            f.create_entity("IfcSIUnit", UnitType="LENGTHUNIT", Name="METRE"),
+            f.create_entity("IfcSIUnit", UnitType="PLANEANGLEUNIT", Name="RADIAN"),
+        ],
+    )
+    wcs = _axis(f)
+    plan = f.create_entity(
+        "IfcGeometricRepresentationContext",
+        ContextType="Plan",
+        CoordinateSpaceDimension=3,
+        Precision=1e-6,
+        WorldCoordinateSystem=wcs,
+    )
+    model = f.create_entity(
+        "IfcGeometricRepresentationContext",
+        ContextType="Model",
+        CoordinateSpaceDimension=3,
+        Precision=1e-6,
+        WorldCoordinateSystem=wcs,
+    )
+    footprint = f.create_entity(
+        "IfcGeometricRepresentationSubContext",
+        ContextIdentifier="FootPrint",
+        ContextType="Model",
+        ParentContext=model,
+        TargetView="MODEL_VIEW",
+    )
+    project.RepresentationContexts = [plan, model]
+
+    storey = f.create_entity(
+        "IfcBuildingStorey", GlobalId=ifcopenshell.guid.new(), Name="Floor 16"
+    )
+    f.create_entity(
+        "IfcRelAggregates",
+        GlobalId=ifcopenshell.guid.new(),
+        RelatingObject=project,
+        RelatedObjects=[storey],
+    )
+
+    # The exporter's quirk: a perfectly good extruded solid, Body identifier, but
+    # attached to the Plan context.
+    profile = f.create_entity(
+        "IfcRectangleProfileDef",
+        ProfileType="AREA",
+        Position=f.create_entity(
+            "IfcAxis2Placement2D",
+            Location=f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0)),
+        ),
+        XDim=1.0,
+        YDim=0.5,
+    )
+    solid = f.create_entity(
+        "IfcExtrudedAreaSolid",
+        SweptArea=profile,
+        Position=_axis(f),
+        ExtrudedDirection=f.create_entity(
+            "IfcDirection", DirectionRatios=(0.0, 0.0, 1.0)
+        ),
+        Depth=0.3,
+    )
+    body = f.create_entity(
+        "IfcShapeRepresentation",
+        ContextOfItems=plan,
+        RepresentationIdentifier="Body",
+        RepresentationType="SweptSolid",
+        Items=[solid],
+    )
+    beam = f.create_entity(
+        "IfcBuildingElementProxy",
+        GlobalId=ifcopenshell.guid.new(),
+        Name="Prefab beam",
+        ObjectPlacement=f.create_entity(
+            "IfcLocalPlacement", RelativePlacement=_axis(f)
+        ),
+        Representation=f.create_entity(
+            "IfcProductDefinitionShape", Representations=[body]
+        ),
+    )
+    elements = [beam]
+
+    if with_grid:
+        # One curve in the Model sub-context is enough to defeat IfcOpenShell's
+        # "no representations in relevant contexts, using all" fallback.
+        line = f.create_entity(
+            "IfcPolyline",
+            Points=[
+                f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0)),
+                f.create_entity("IfcCartesianPoint", Coordinates=(10.0, 0.0, 0.0)),
+            ],
+        )
+        grid_axis = f.create_entity(
+            "IfcGridAxis", AxisTag="A", AxisCurve=line, SameSense=True
+        )
+        grid_rep = f.create_entity(
+            "IfcShapeRepresentation",
+            ContextOfItems=footprint,
+            RepresentationIdentifier="FootPrint",
+            RepresentationType="GeometricCurveSet",
+            Items=[f.create_entity("IfcGeometricCurveSet", Elements=[line])],
+        )
+        grid = f.create_entity(
+            "IfcGrid",
+            GlobalId=ifcopenshell.guid.new(),
+            Name="Grid",
+            ObjectPlacement=f.create_entity(
+                "IfcLocalPlacement", RelativePlacement=_axis(f)
+            ),
+            Representation=f.create_entity(
+                "IfcProductDefinitionShape", Representations=[grid_rep]
+            ),
+            UAxes=[grid_axis],
+            VAxes=[],
+        )
+        elements.append(grid)
+
+    f.create_entity(
+        "IfcRelContainedInSpatialStructure",
+        GlobalId=ifcopenshell.guid.new(),
+        RelatingStructure=storey,
+        RelatedElements=elements,
+    )
+    return f, plan, model, footprint
+
+
+def test_context_ids_are_a_superset_of_the_default_widened_by_body_contexts():
+    f, plan, model, footprint = _plan_context_body_file(with_grid=True)
+    assert contexts_for_3d_representations(f) == sorted(
+        {plan.id(), model.id(), footprint.id()}
+    )
+
+
+def test_default_selection_misses_plan_context_bodies_when_a_model_curve_exists():
+    """Pins the IfcOpenShell behaviour the retry exists for. If this starts passing
+    with the default iterator, the fallback has become unnecessary upstream."""
+    f, *_ = _plan_context_body_file(with_grid=True)
+    assert create_geometry_iterator(f).initialize() is False
+    assert create_geometry_iterator(f, contexts_for_3d_representations(f)).initialize()
+
+
+def test_default_selection_still_finds_plan_context_bodies_without_the_curve():
+    f, *_ = _plan_context_body_file(with_grid=False)
+    assert create_geometry_iterator(f).initialize()
+
+
+def test_import_job_converts_the_beam_via_the_context_retry(tmp_path):
+    f, *_ = _plan_context_body_file(with_grid=True)
+    job = ImportJob(f, str(tmp_path), "precast", _NoProgress())
+    job.run()
+    assert job.geometries_count == 1


### PR DESCRIPTION
after fix

<img width="1572" height="1274" alt="Screenshot 2026-09-04 at 17 12 54" src="https://github.com/user-attachments/assets/6d021f3a-841d-48e5-92dd-a84a0622f409" />

## Problem

Eight per-floor precast IFCs (ICPrefab / iTConcrete export, IFC2X3) from one production project failed with `Failed to find any geometry in file` while two sibling floors from the same export, and every failing floor's `.nwc` twin, converted fine. [ENG-9524](https://linear.app/speckle/issue/ENG-9524).

The geometry is sound (`ifcopenshell.geom.create_shape` meshes every element). What fails is IfcOpenShell's **context-first** representation selection (`mapping.cpp` `addRepresentationsFromDefaultContexts`):

1. keep top-level contexts of type `Model`/`Design` (+ their sub-contexts); `Plan` is dropped for surfaces-and-solids output,
2. collect every representation in them,
3. only if that collection is **empty**, fall back to "all contexts".

The exporter attaches **every `Body` representation to the `Plan` context**. That alone is survivable (the fallback fires). But the eight failing floors also contain one `IfcGrid` whose `FootPrint` curve set sits in a sub-context of `Model`. One curve is enough to make step 2 non-empty, the fallback never fires, the 879–3644 solids in the Plan context are never considered, and `iterator.initialize()` returns false.

## Fix

When `initialize()` fails, rebuild the iterator once with `context-ids` = IfcOpenShell's own default choice **widened by every context a 3D-typed shape representation points at** — a strict superset of the default, so nothing the default converts is lost — and log the retry. Files that convert today never reach the retry branch, so existing behaviour is untouched by construction.

The warning line is deliberate: its frequency in production decides whether the evidence-based selection should become unconditional (which would also catch the silent variant where bodies are split across Model and Plan contexts).

## Verification

- All 10 floors of the production batch convert locally (8 via the retry, the 2 controls without it), element counts match the files (847–3520).
- New `tests/bundle/test_ifc_context_fallback.py` builds a minimal IFC2X3 with the same pathology and pins both the IfcOpenShell behaviour and the retry; `tests/bundle` suite: 177 passed.
- Built `.dat`s for all ten floors render in the WebGPU viewer sandbox.

Side finding, not addressed here: `ifc-25132-gebouw-e-hofvanbaarn.ifc` from the same batch is an ifcZIP archive renamed `.ifc` and needs a clearer message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7L9MimqMsgyvVCyXv45SB